### PR TITLE
[Code_Exercises] Addressed the execution failure issue in Intel DevCl…

### DIFF
--- a/Code_Exercises/Exercise_2_Configuring_a_Queue/doc.md
+++ b/Code_Exercises/Exercise_2_Configuring_a_Queue/doc.md
@@ -61,7 +61,14 @@ score will never be chosen.
 For For DPC++ (using the Intel DevCloud):
 ```
 dpcpp -o sycl-ex-2 -I../External/Catch2/single_include ../Code_Exercises/Exercise_2_Configuring_a_Queue/source.cpp
-./sycl-ex-2
+```
+In Intel DevCloud, to run computational applications, you will submit jobs to a queue for execution on compute nodes,
+especially some features like longer walltime and multi-node computation is only abvailable through the job queue.
+Please refer to the [example][devcloud-job-submission].
+
+So wrap the binary into a script `job_submission` and run:
+```
+qsub job_submission
 ```
 
 For ComputeCpp:
@@ -90,3 +97,4 @@ HIPSYCL_PLATFORM=<cpu|cuda|rocm> HIPSYCL_GPU_ARCH=<arch-when-compiling-for-gpu> 
 
 
 [sycl-specification]: https://www.khronos.org/registry/SYCL/specs/sycl-1.2.1.pdf
+[devcloud-job-submission]: https://devcloud.intel.com/oneapi/learn/advanced-queue/basic-job-submission#command-file-job-script-


### PR DESCRIPTION
…oud.

According to the guidance:
https://devcloud.intel.com/oneapi/learn/advanced-queue/about-the-job-queue

some executions (jobs) need to be submitted into a queue, otherwise
directly running the compiled binary would cause such error:
"thread_monitor Resource temporarily unavailable in pthread_create".

Note: the similar change should be also applied for other exercises from
      3~7, or there should be a common notification (under Code_Exercises)
      about this.

Signed-off-by: Austin Hu <austin.hu@intel.com>