### PR TITLE
Updating 'Data Parallelism' and 'Using USM' lectures

### DIFF
--- a/Lesson_Materials/Lecture_6_Data_Parallelism/index.html
+++ b/Lesson_Materials/Lecture_6_Data_Parallelism/index.html
@@ -210,7 +210,7 @@ parallel_for(calc, in, out, 1024);
 					<div class="container">
 						<div class="col">
 							<code><pre>
-cgh.<mark>parallel_for</mark>&lt;my_kernel&gt;/mark><T>(<mark>range{64, 64}</mark>, 
+cgh.<mark>parallel_for</mark>&lt;my_kernel&gt;(<mark>range{64, 64}</mark>, 
                           [=](id&lt;2&gt; idx){
   // SYCL kernel function is executed 
   // on a range of work-items
@@ -234,7 +234,7 @@ cgh.<mark>parallel_for</mark>&lt;my_kernel&gt;/mark><T>(<mark>range{64, 64}</mar
 					<div class="container">
 						<div class="col">
 							<code><pre>
-cgh.parallel_for<&lt;my_kernel&gt;/mark><T>(range{64, 64}, 
+cgh.parallel_for&lt;my_kernel&gt;(range{64, 64}, 
                           [=](<mark>id&lt;2&gt; idx</mark>){
   // SYCL kernel function is executed 
   // on a range of work-items
@@ -248,6 +248,47 @@ cgh.parallel_for<&lt;my_kernel&gt;/mark><T>(range{64, 64},
 					  an `id`.
 					  * This represents the current work-item being executed and
 					  it's position within the iteration space.
+					</div>
+				</section>
+								<!--Slide 12-->
+				<section>
+					<div class="hbox" data-markdown>
+						#### Expressing parallelism
+					</div>
+					<div class="container">
+						<div class="col">
+							<code><pre>
+							
+cgh.parallel_for&ltkernel&gt(<mark>range&lt1&gt(1024)</mark>, 
+  [=](<mark>id&lt1&gt idx</mark>){
+    /* kernel function code */
+});
+							</code></pre>
+							<code><pre>
+							
+cgh.parallel_for&ltkernel&gt(<mark>range&lt1&gt(1024)</mark>, 
+  [=](<mark>item&lt1&gt item</mark>){
+    /* kernel function code */
+});
+							</code></pre>
+							<code><pre>
+							
+cgh.parallel_for&ltkernel&gt(nd_range&lt1&gt(<mark>range&lt1&gt(1024), 
+  range&lt1&gt(32))</mark>,[=](<mark>nd_item&lt1&gt ndItem</mark>){
+    /* kernel function code */
+});
+							</code></pre>
+						</div>
+						<div class="col" data-markdown>
+							* Overload taking a **range** object specifies the global range, runtime decides local range
+							* An **id** parameter represents the index within the global range
+							____________________________________________________________________________________________
+							* Overload taking a **range** object specifies the global range, runtime decides local range
+							* An **item** parameter represents the global range and the index within the global range
+							____________________________________________________________________________________________
+							* Overload taking an **nd_range** object specifies the global and local range
+							* An **nd_item** parameter represents the global and local range and index
+						</div>
 					</div>
 				</section>
 				<!--Slide 12-->

--- a/Lesson_Materials/Lecture_8_Using_USM/index.html
+++ b/Lesson_Materials/Lecture_8_Using_USM/index.html
@@ -83,16 +83,17 @@
 					</div>
 					<div class="container">
 						<code class="code-100pc"><pre>
-void* malloc_device(size_t num_bytes, const queue& queue);
+void* malloc_device(size_t numBytes, const queue& syclQueue, const property_list &propList = {});
 
 template &lt;typename T&gt;
-T* malloc_device(size_t count, const queue& queue);
+T* malloc_device(size_t count, const queue& syclQueue,  const property_list &propList = {});
 						</code></pre>
 					</div>
 					<div class="container" data-markdown>
 						* A USM device allocation is performed by calling one of the `malloc_device` functions.
 						* Both of these functions allocate the specified region of memory on the `device` associated with the specified `queue`.
 						* The pointer returned is only accessible in a kernel function running on that `device`.
+						* Synchronous exception if the device does not have aspect::usm_device_allocations
 						* This is a blocking operation.
 					</div>
 				</section>
@@ -103,7 +104,7 @@ T* malloc_device(size_t count, const queue& queue);
 					</div>
 					<div class="container">
 						<code class="code-100pc"><pre>
-void free(void* ptr, queue& queue);
+void free(void* ptr, queue& syclQueue);
 						</code></pre>
 					</div>
 					<div class="container" data-markdown>
@@ -119,14 +120,15 @@ void free(void* ptr, queue& queue);
 					</div>
 					<div class="container">
 						<code class="code-100pc"><pre>
-event queue::memcpy(void* dest, const void* src, size_t num_bytes);
+event queue::memcpy(void* dest, const void* src, size_t numBytes, const std::vector<event> &depEvents);
 						</code></pre>
 					</div>
 					<div class="container" data-markdown>
 						* Data can be copied to and from a USM device allocation by calling the `queue`'s `memcpy` member function.
 						* The source and destination can be either a host application pointer or a USM device allocation.
 						* This is an asynchronous operation enqueued to the `queue`.
-						*An `event` is returned which can be used to synchronize with the completion of copy operation.
+						* An `event` is returned which can be used to synchronize with the completion of copy operation.
+						* May depend on other events via `depEvents`
 					</div>
 				</section>
 				<!--Slide 7-->
@@ -136,9 +138,9 @@ event queue::memcpy(void* dest, const void* src, size_t num_bytes);
 					</div>
 					<div class="container">
 						<code class="code-100pc"><pre>
-event queue::memset(void* ptr, int value, size_t num_bytes);
+event queue::memset(void* ptr, int value, size_t numBytes, const std::vector<event> &depEvents);
 
-event queue::fill(void* ptr, const T& pattern, size_t count);
+event queue::fill(void* ptr, const T& pattern, size_t count, const std::vector<event> &depEvents);
 						</code></pre>
 					</div>
 					<div class="container" data-markdown>


### PR DESCRIPTION
- Corrected minor typos on slides 10 and 11 in 'Data Parallelism' lecture
- Added a summary slide with all options to invoke parallel_for (including nd-ranges)
- Updated 'Using USM' lecture to reflect latest changes in SYCL2020 (new functions interfaces)