### PR TITLE
Update hipSYCL exercise instructions

### DIFF
--- a/Code_Exercises/Exercise_01_Compiling_with_SYCL/doc.md
+++ b/Code_Exercises/Exercise_01_Compiling_with_SYCL/doc.md
@@ -4,16 +4,20 @@
 
 ---
 
-For this first exercise you simply need to install ComputeCpp and the SYCL
+For this first exercise you simply need to install a SYCL implementation and the SYCL
 Academy dependencies and then verify your installation by comping a source file
 for SYCL.
 
-### 1.) Installing ComputeCpp
+### 1.) Installing a SYCL implementation
 
-To install ComputeCpp follow the instructions in the README.md of the SYCL
-Academy repository for installing ComputeCpp and the necessary OpenCL drivers.
+To install a SYCL implementation, follow the instructions in the README.md of the SYCL
+Academy repository.
 
 ### 2.) Verifying your environment
+
+Depending on the SYCL implementation used, the steps to verify your environment might vary.
+
+#### When using ComputeCpp
 
 ComputeCpp includes a tool called `computecpp_info` which lists all the
 devices available on your machine and displays which are setup with the correct
@@ -36,6 +40,17 @@ You can also add the option --verbose to display further information about the
 devices.
 
 From this output you can confirm your environment is setup correctly.
+
+#### When using hipSYCL
+
+With hipSYCL, you can skip this step. If you suspect later that your environment might not be set up correctly, you can set the environment variable `HIPSYCL_DEBUG_LEVEL=3` and execute your program. hipSYCL will then print (among many other things) all devices that it can find, for example:
+```sh
+[hipSYCL Info] Discovered devices from backend 'OpenMP': 
+[hipSYCL Info]   device 0: 
+[hipSYCL Info]     vendor: the hipSYCL project
+[hipSYCL Info]     name: hipSYCL OpenMP host device
+```
+*Note: You may not see this output in this exercise because we do not yet actually use any SYCL functionality. Consequently, there is no need for the hipSYCL runtime to launch and print diagnostic information.*
 
 ### 3.) Configuring the exercise project
 
@@ -93,16 +108,17 @@ make exercise_01_compiling_with_sycl_source
 
 For hipSYCL:
 ```sh
-# Add -DHIPSYCL_GPU_ARCH=<arch> to the cmake arguments when compiling for GPUs.
-# <arch> is e.g. sm_60 for NVIDIA Pascal GPUs, gfx900 for AMD Vega 56/64, and gfx906 for Radeon VII.
-cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_PLATFORM=<cpu|cuda|rocm> ..
+# <target specification> is a list of backends and devices to target, for example
+# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
+cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_TARGETS="<target specification>" ..
 make exercise_01_compiling_with_sycl_source
 ./Code_Exercises/Exercise_01_compiling_with_SYCL/exercise_01_compiling_with_sycl_source
 ```
 alternatively, without cmake:
 ```sh
 cd Code_Exercises/Exercise_01_compiling_with_SYCL
-HIPSYCL_PLATFORM=<cpu|cuda|rocm> HIPSYCL_GPU_ARCH=<arch-when-compiling-for-gpu> /path/to/hipsycl/bin/syclcc -o sycl-ex-1 -I../../External/Catch2/single_include source.cpp
+/path/to/hipsycl/bin/syclcc -o sycl-ex-1 -I../../External/Catch2/single_include --hipsycl-targets="<target specification>" source.cpp
 ./sycl-ex-1
 ```
 

--- a/Code_Exercises/Exercise_02_Hello_World/doc.md
+++ b/Code_Exercises/Exercise_02_Hello_World/doc.md
@@ -71,16 +71,17 @@ make exercise_02_hello_world_source
 
 For hipSYCL:
 ```sh
-# Add -DHIPSYCL_GPU_ARCH=<arch> to the cmake arguments when compiling for GPUs.
-# <arch> is e.g. sm_60 for NVIDIA Pascal GPUs, gfx900 for AMD Vega 56/64, and gfx906 for Radeon VII.
-cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_PLATFORM=<cpu|cuda|rocm> ..
+# <target specification> is a list of backends and devices to target, for example
+# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
+cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_TARGETS="<target specification>" ..
 make exercise_02_hello_world_source
 ./Code_Exercises/Exercise_02_Hello_World/exercise_02_hello_world_source
 ```
 alternatively, without cmake:
 ```sh
 cd Code_Exercises/Exercise_02_Hello_World
-HIPSYCL_PLATFORM=<cpu|cuda|rocm> HIPSYCL_GPU_ARCH=<arch-when-compiling-for-gpu> /path/to/hipsycl/bin/syclcc -o sycl-ex-2 -I../../External/Catch2/single_include source.cpp
+/path/to/hipsycl/bin/syclcc -o sycl-ex-2 -I../../External/Catch2/single_include --hipsycl-targets="<target specification>" source.cpp
 ./sycl-ex-2
 ```
 

--- a/Code_Exercises/Exercise_03_Scalar_Add/doc.md
+++ b/Code_Exercises/Exercise_03_Scalar_Add/doc.md
@@ -78,16 +78,17 @@ make exercise_03_scalar_add_source
 
 For hipSYCL:
 ```sh
-# Add -DHIPSYCL_GPU_ARCH=<arch> to the cmake arguments when compiling for GPUs.
-# <arch> is e.g. sm_60 for NVIDIA Pascal GPUs, gfx900 for AMD Vega 56/64, and gfx906 for Radeon VII.
-cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_PLATFORM=<cpu|cuda|rocm> ..
+# <target specification> is a list of backends and devices to target, for example
+# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
+cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_TARGETS="<target specification>" ..
 make exercise_03_scalar_add_source
 ./Code_Exercises/Exercise_03_Scalar_Add/exercise_03_scalar_add_source
 ```
 alternatively, without cmake:
 ```sh
-cd Code_Exercises/Exercise_03_Scalar_Add/
-HIPSYCL_PLATFORM=<cpu|cuda|rocm> HIPSYCL_GPU_ARCH=<arch-when-compiling-for-gpu> /path/to/hipsycl/bin/syclcc -o sycl-ex-3 -I../../External/Catch2/single_include source.cpp
+cd Code_Exercises/Exercise_03_Scalar_Add
+/path/to/hipsycl/bin/syclcc -o sycl-ex-3 -I../../External/Catch2/single_include --hipsycl-targets="<target specification>" source.cpp
 ./sycl-ex-3
 ```
 

--- a/Code_Exercises/Exercise_04_Handling_Errors/doc.md
+++ b/Code_Exercises/Exercise_04_Handling_Errors/doc.md
@@ -52,16 +52,17 @@ make exercise_04_handling_errors_source
 
 For hipSYCL:
 ```sh
-# Add -DHIPSYCL_GPU_ARCH=<arch> to the cmake arguments when compiling for GPUs.
-# <arch> is e.g. sm_60 for NVIDIA Pascal GPUs, gfx900 for AMD Vega 56/64, and gfx906 for Radeon VII.
-cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_PLATFORM=<cpu|cuda|rocm> ..
-make exercise_04_handling_errors source
-./Code_Exercises/Exercise_04_Handling_Errors/exercise_04_handling_errors source
+# <target specification> is a list of backends and devices to target, for example
+# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
+cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_TARGETS="<target specification>" ..
+make exercise_04_handling_errors_source
+./Code_Exercises/Exercise_04_Handling_Errors/exercise_04_handling_errors_source
 ```
 alternatively, without cmake:
 ```sh
 cd Code_Exercises/Exercise_04_Handling_Errors
-HIPSYCL_PLATFORM=<cpu|cuda|rocm> HIPSYCL_GPU_ARCH=<arch-when-compiling-for-gpu> /path/to/hipsycl/bin/syclcc -o sycl-ex-4 -I../../External/Catch2/single_include source.cpp
+/path/to/hipsycl/bin/syclcc -o sycl-ex-4 -I../../External/Catch2/single_include --hipsycl-targets="<target specification>" source.cpp
 ./sycl-ex-4
 ```
 

--- a/Code_Exercises/Exercise_05_Device_Selection/doc.md
+++ b/Code_Exercises/Exercise_05_Device_Selection/doc.md
@@ -142,16 +142,17 @@ make exercise_05_device_selection_source
 
 For hipSYCL:
 ```sh
-# Add -DHIPSYCL_GPU_ARCH=<arch> to the cmake arguments when compiling for GPUs.
-# <arch> is e.g. sm_60 for NVIDIA Pascal GPUs, gfx900 for AMD Vega 56/64, and gfx906 for Radeon VII.
-cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_PLATFORM=<cpu|cuda|rocm> ..
+# <target specification> is a list of backends and devices to target, for example
+# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
+cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_TARGETS="<target specification>" ..
 make exercise_05_device_selection_source
-./Code_Exercises/Exercise_05_Device_Selection/exercise_04_handling_errors source
+./Code_Exercises/Exercise_05_Device_Selection/exercise_05_device_selection_source
 ```
 alternatively, without cmake:
 ```sh
 cd Code_Exercises/Exercise_05_Device_Selection
-HIPSYCL_PLATFORM=<cpu|cuda|rocm> HIPSYCL_GPU_ARCH=<arch-when-compiling-for-gpu> /path/to/hipsycl/bin/syclcc -o sycl-ex-5 -I../../External/Catch2/single_include source.cpp
+/path/to/hipsycl/bin/syclcc -o sycl-ex-5 -I../../External/Catch2/single_include --hipsycl-targets="<target specification>" source.cpp
 ./sycl-ex-5
 ```
 

--- a/Code_Exercises/Exercise_06_Vector_Add/doc.md
+++ b/Code_Exercises/Exercise_06_Vector_Add/doc.md
@@ -128,16 +128,17 @@ make exercise_06_vector_add source
 
 For hipSYCL:
 ```sh
-# Add -DHIPSYCL_GPU_ARCH=<arch> to the cmake arguments when compiling for GPUs.
-# <arch> is e.g. sm_60 for NVIDIA Pascal GPUs, gfx900 for AMD Vega 56/64, and gfx906 for Radeon VII.
-cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_PLATFORM=<cpu|cuda|rocm> ..
-make exercise_06_vector_add source
-./Code_Exercises/Exercise_06_Vector_Add/exercise_06_vector_add source
+# <target specification> is a list of backends and devices to target, for example
+# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
+cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_TARGETS="<target specification>" ..
+make exercise_06_vector_add
+./Code_Exercises/Exercise_06_Vector_Add/exercise_06_vector_add_source
 ```
 alternatively, without cmake:
 ```sh
 cd Code_Exercises/Exercise_06_Vector_Add
-HIPSYCL_PLATFORM=<cpu|cuda|rocm> HIPSYCL_GPU_ARCH=<arch-when-compiling-for-gpu> /path/to/hipsycl/bin/syclcc -o sycl-ex-6 -I../../External/Catch2/single_include source.cpp
+/path/to/hipsycl/bin/syclcc -o sycl-ex-6 -I../../External/Catch2/single_include --hipsycl-targets="<target specification>" source.cpp
 ./sycl-ex-6
 ```
 

--- a/Code_Exercises/Exercise_07_USM_Selector/doc.md
+++ b/Code_Exercises/Exercise_07_USM_Selector/doc.md
@@ -116,16 +116,17 @@ make exercise_07_usm_selector_source
 
 For hipSYCL:
 ```sh
-# Add -DHIPSYCL_GPU_ARCH=<arch> to the cmake arguments when compiling for GPUs.
-# <arch> is e.g. sm_60 for NVIDIA Pascal GPUs, gfx900 for AMD Vega 56/64, and gfx906 for Radeon VII.
-cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_PLATFORM=<cpu|cuda|rocm> ..
+# <target specification> is a list of backends and devices to target, for example
+# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
+cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_TARGETS="<target specification>" ..
 make exercise_07_usm_selector_source
 ./Code_Exercises/Exercise_07_USM_Selector/exercise_07_usm_selector_source
 ```
 alternatively, without cmake:
 ```sh
 cd Code_Exercises/Exercise_07_USM_Selector
-HIPSYCL_PLATFORM=<cpu|cuda|rocm> HIPSYCL_GPU_ARCH=<arch-when-compiling-for-gpu> /path/to/hipsycl/bin/syclcc -o sycl-ex-7 -I../../External/Catch2/single_include source.cpp
+/path/to/hipsycl/bin/syclcc -o sycl-ex-7 -I../../External/Catch2/single_include --hipsycl-targets="<target specification>" source.cpp
 ./sycl-ex-7
 ```
 

--- a/Code_Exercises/Exercise_08_USM_Vector_Add/doc.md
+++ b/Code_Exercises/Exercise_08_USM_Vector_Add/doc.md
@@ -161,16 +161,17 @@ make exercise_08_usm_vector_add_source
 
 For hipSYCL:
 ```sh
-# Add -DHIPSYCL_GPU_ARCH=<arch> to the cmake arguments when compiling for GPUs.
-# <arch> is e.g. sm_60 for NVIDIA Pascal GPUs, gfx900 for AMD Vega 56/64, and gfx906 for Radeon VII.
-cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_PLATFORM=<cpu|cuda|rocm> ..
+# <target specification> is a list of backends and devices to target, for example
+# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
+cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_TARGETS="<target specification>" ..
 make exercise_08_usm_vector_add_source
 ./Code_Exercises/Exercise_08_USM_Vector_Add/exercise_08_usm_vector_add_source
 ```
 alternatively, without cmake:
 ```sh
 cd Code_Exercises/Exercise_08_USM_Vector_Add
-HIPSYCL_PLATFORM=<cpu|cuda|rocm> HIPSYCL_GPU_ARCH=<arch-when-compiling-for-gpu> /path/to/hipsycl/bin/syclcc -o sycl-ex-8 -I../../External/Catch2/single_include source.cpp
+/path/to/hipsycl/bin/syclcc -o sycl-ex-8 -I../../External/Catch2/single_include --hipsycl-targets="<target specification>" source.cpp
 ./sycl-ex-8
 ```
 

--- a/Code_Exercises/Exercise_09_Synchronization/doc.md
+++ b/Code_Exercises/Exercise_09_Synchronization/doc.md
@@ -140,16 +140,17 @@ make exercise_09_synchronization_source
 
 For hipSYCL:
 ```sh
-# Add -DHIPSYCL_GPU_ARCH=<arch> to the cmake arguments when compiling for GPUs.
-# <arch> is e.g. sm_60 for NVIDIA Pascal GPUs, gfx900 for AMD Vega 56/64, and gfx906 for Radeon VII.
-cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_PLATFORM=<cpu|cuda|rocm> ..
+# <target specification> is a list of backends and devices to target, for example
+# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
+cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_TARGETS="<target specification>" ..
 make exercise_09_synchronization_source
 ./Code_Exercises/Exercise_09_Synchronization/exercise_09_synchronization_source
 ```
 alternatively, without cmake:
 ```sh
 cd Code_Exercises/Exercise_09_Synchronization
-HIPSYCL_PLATFORM=<cpu|cuda|rocm> HIPSYCL_GPU_ARCH=<arch-when-compiling-for-gpu> /path/to/hipsycl/bin/syclcc -o sycl-ex-9 -I../../External/Catch2/single_include source.cpp
+/path/to/hipsycl/bin/syclcc -o sycl-ex-9 -I../../External/Catch2/single_include --hipsycl-targets="<target specification>" source.cpp
 ./sycl-ex-9
 ```
 

--- a/Code_Exercises/Exercise_10_Managing_Dependencies/doc.md
+++ b/Code_Exercises/Exercise_10_Managing_Dependencies/doc.md
@@ -131,18 +131,18 @@ make exercise_10_managing_dependencies_source
 
 For hipSYCL:
 ```sh
-# Add -DHIPSYCL_GPU_ARCH=<arch> to the cmake arguments when compiling for GPUs.
-# <arch> is e.g. sm_60 for NVIDIA Pascal GPUs, gfx900 for AMD Vega 56/64, and gfx906 for Radeon VII.
-cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_PLATFORM=<cpu|cuda|rocm> ..
+# <target specification> is a list of backends and devices to target, for example
+# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
+cmake -DSYCL_ACADEMY_USE_HIPSYCL=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/hipsycl -DHIPSYCL_TARGETS="<target specification>" ..
 make exercise_10_managing_dependencies_source
 ./Code_Exercises/Exercise_10_Managing_Dependencies/exercise_10_managing_dependencies_source
 ```
 alternatively, without cmake:
 ```sh
 cd Code_Exercises/Exercise_10_Managing_Dependencies
-HIPSYCL_PLATFORM=<cpu|cuda|rocm> HIPSYCL_GPU_ARCH=<arch-when-compiling-for-gpu> /path/to/hipsycl/bin/syclcc -o sycl-ex-10 -I../../External/Catch2/single_include source.cpp
+/path/to/hipsycl/bin/syclcc -o sycl-ex-10 -I../../External/Catch2/single_include --hipsycl-targets="<target specification>" source.cpp
 ./sycl-ex-10
 ```
-
 
 [devcloud-job-submission]: https://devcloud.intel.com/oneapi/documentation/job-submission/


### PR DESCRIPTION
Sorry, another last minute change
* Update compilation hints in exercise documentation to use `--hipsycl-targets` instead of deprecated `--hipsycl-platform`
* Generalize exercise 1 documentation to not assume ComputeCpp exclusively