### PR TITLE
Adopt exercises 9 and 10 for dpcpp

### DIFF
--- a/Code_Exercises/Exercise_09_Synchronization/solution.cpp
+++ b/Code_Exercises/Exercise_09_Synchronization/solution.cpp
@@ -53,7 +53,7 @@ TEST_CASE("buffer_accessor_event_wait", "synchronization_solution") {
 #if defined(SYCL_LANGUAGE_VERSION) && defined(__INTEL_LLVM_COMPILER)
     auto defaultQueue = sycl::queue{sycl::default_selector{}, asyncHandler};
 #else
-	auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
+    auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
 #endif
     auto bufA = sycl::buffer{a, sycl::range{dataSize}};
     auto bufB = sycl::buffer{b, sycl::range{dataSize}};
@@ -101,7 +101,7 @@ TEST_CASE("buffer_accessor_queue_wait", "synchronization_solution") {
 #if defined(SYCL_LANGUAGE_VERSION) && defined(__INTEL_LLVM_COMPILER)
     auto defaultQueue = sycl::queue{sycl::default_selector{}, asyncHandler};
 #else
-	auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
+    auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
 #endif
 
     auto bufA = sycl::buffer{a, sycl::range{dataSize}};
@@ -148,7 +148,7 @@ TEST_CASE("buffer_accessor_buffer_dest", "synchronization_solution") {
 #if defined(SYCL_LANGUAGE_VERSION) && defined(__INTEL_LLVM_COMPILER)
     auto defaultQueue = sycl::queue{sycl::default_selector{}, asyncHandler};
 #else
-	auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
+    auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
 #endif
 
     {
@@ -329,7 +329,7 @@ TEST_CASE("host_accessor", "synchronization_solution") {
 #if defined(SYCL_LANGUAGE_VERSION) && defined(__INTEL_LLVM_COMPILER)
     auto defaultQueue = sycl::queue{sycl::default_selector{}, asyncHandler};
 #else
-	auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
+    auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
 #endif
 
     {

--- a/Code_Exercises/Exercise_09_Synchronization/solution.cpp
+++ b/Code_Exercises/Exercise_09_Synchronization/solution.cpp
@@ -50,9 +50,11 @@ TEST_CASE("buffer_accessor_event_wait", "synchronization_solution") {
         std::rethrow_exception(e);
       }
     };
-
-    auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
-
+#if defined(SYCL_LANGUAGE_VERSION) && defined(__INTEL_LLVM_COMPILER)
+    auto defaultQueue = sycl::queue{sycl::default_selector{}, asyncHandler};
+#else
+	auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
+#endif
     auto bufA = sycl::buffer{a, sycl::range{dataSize}};
     auto bufB = sycl::buffer{b, sycl::range{dataSize}};
     auto bufR = sycl::buffer{r, sycl::range{dataSize}};
@@ -96,7 +98,11 @@ TEST_CASE("buffer_accessor_queue_wait", "synchronization_solution") {
       }
     };
 
-    auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
+#if defined(SYCL_LANGUAGE_VERSION) && defined(__INTEL_LLVM_COMPILER)
+    auto defaultQueue = sycl::queue{sycl::default_selector{}, asyncHandler};
+#else
+	auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
+#endif
 
     auto bufA = sycl::buffer{a, sycl::range{dataSize}};
     auto bufB = sycl::buffer{b, sycl::range{dataSize}};
@@ -139,7 +145,11 @@ TEST_CASE("buffer_accessor_buffer_dest", "synchronization_solution") {
       }
     };
 
-    auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
+#if defined(SYCL_LANGUAGE_VERSION) && defined(__INTEL_LLVM_COMPILER)
+    auto defaultQueue = sycl::queue{sycl::default_selector{}, asyncHandler};
+#else
+	auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
+#endif
 
     {
       auto bufA = sycl::buffer{a, sycl::range{dataSize}};
@@ -316,7 +326,11 @@ TEST_CASE("host_accessor", "synchronization_solution") {
       }
     };
 
-    auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
+#if defined(SYCL_LANGUAGE_VERSION) && defined(__INTEL_LLVM_COMPILER)
+    auto defaultQueue = sycl::queue{sycl::default_selector{}, asyncHandler};
+#else
+	auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
+#endif
 
     {
       auto bufA = sycl::buffer{a, sycl::range{dataSize}};

--- a/Code_Exercises/Exercise_10_Managing_Dependencies/solution.cpp
+++ b/Code_Exercises/Exercise_10_Managing_Dependencies/solution.cpp
@@ -54,7 +54,11 @@ TEST_CASE("buffer_accessor_diamond", "managing_dependencies_solution") {
       }
     };
 
-    auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
+#if defined(SYCL_LANGUAGE_VERSION) && defined(__INTEL_LLVM_COMPILER)
+    auto defaultQueue = sycl::queue{sycl::default_selector{}, asyncHandler};
+#else
+	auto defaultQueue = sycl::queue{sycl::default_selector_v, asyncHandler};
+#endif
 
     auto bufInA = sycl::buffer{inA, sycl::range{dataSize}};
     auto bufInB = sycl::buffer{inB, sycl::range{dataSize}};
@@ -172,7 +176,13 @@ TEST_CASE("usm_diamond", "usm_vector_add_solution") {
               devicePtrInB[globalId] + devicePtrInC[globalId];
         });
 
-    auto e8 = usmQueue.memcpy(out, devicePtrOut, sizeof(float) * dataSize, e7);
+#if defined(SYCL_LANGUAGE_VERSION) && defined(__INTEL_LLVM_COMPILER)
+    e7.wait();
+    auto e8 = usmQueue.memcpy(out, devicePtrOut, sizeof(float) * dataSize);
+#else
+	auto e8 = usmQueue.memcpy(out, devicePtrOut, sizeof(float) * dataSize, e7);
+#endif
+
 
     e8.wait();
 


### PR DESCRIPTION
Applying workarounds to  exercises 9 and 10 to be compilable with dpcpp

- Avoid new default_selector_v class
- Avoid event object to be passed to USM memcpy function