### PR TITLE
Update to include minimum version of ComputeCpp

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ may not match completely.
 
 ## Building the Exercises
 
-The exercises can be built for ComputeCpp CE, DPC++ and hipSYCL.
+The exercises can be built for ComputeCpp CE (minimum v2.6.0), DPC++ and hipSYCL.
 
 ### Supported Platforms
 


### PR DESCRIPTION
This is due to SYCL 2020 features used in the latest exercises.