### PR TITLE
Add serial starting codes to the starting source

### DIFF
--- a/Code_Exercises/Exercise_01_Compiling_with_SYCL/solution.cpp
+++ b/Code_Exercises/Exercise_01_Compiling_with_SYCL/solution.cpp
@@ -17,6 +17,7 @@
 #include <CL/sycl.hpp>
 #endif
 
+// The below tests that the header file has been included
 TEST_CASE("empty_sycl_source_file", "compiling_with_sycl_solution") {
   REQUIRE(true);
 }

--- a/Code_Exercises/Exercise_01_Compiling_with_SYCL/source.cpp
+++ b/Code_Exercises/Exercise_01_Compiling_with_SYCL/source.cpp
@@ -11,6 +11,10 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
+// Task: Include SYCL header file
+
+
+// The below tests that the header file has been included
 TEST_CASE("empty_sycl_source_file", "compiling_with_sycl_source") {
   REQUIRE(true);
 }

--- a/Code_Exercises/Exercise_02_Hello_World/source.cpp
+++ b/Code_Exercises/Exercise_02_Hello_World/source.cpp
@@ -12,5 +12,11 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("hello_world", "hello_world_source") {
+
+  // Print "Hello World!\n"
+  std::cout << "Hello World!\n";
+
+  // Task: Have this message print from the SYCL device instead of the host
+
   REQUIRE(true);
 }

--- a/Code_Exercises/Exercise_03_Scalar_Add/source.cpp
+++ b/Code_Exercises/Exercise_03_Scalar_Add/source.cpp
@@ -12,5 +12,12 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("scalar_add", "scalar_add_source") {
-  REQUIRE(true);
+
+  int a = 18, b = 24, r = 0;
+
+  // Task: Compute a+b on the SYCL device
+  r = a + b;
+
+
+  REQUIRE(r == 42);
 }

--- a/Code_Exercises/Exercise_04_Handling_Errors/source.cpp
+++ b/Code_Exercises/Exercise_04_Handling_Errors/source.cpp
@@ -12,5 +12,30 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("handling_errors", "handling_errors_source") {
-  REQUIRE(true);
+
+  // This program computes r = a + b
+  int a = 18, b = 24, r = 0;
+
+
+  // Task: catch synchronous and asynchronous exceptions
+
+  auto defaultQueue = sycl::queue{asyncHandler};
+
+  {
+    auto bufA = sycl::buffer{&a, sycl::range{1}};
+    auto bufB = sycl::buffer{&b, sycl::range{1}};
+    auto bufR = sycl::buffer{&r, sycl::range{1}};
+
+    defaultQueue
+        .submit([&](sycl::handler& cgh) {
+          auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
+          auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
+          auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
+
+          cgh.single_task<scalar_add>([=]() { accR[0] = accA[0] + accB[0]; });
+        })
+        .wait();
+  }
+
+  REQUIRE(r == 42);
 }

--- a/Code_Exercises/Exercise_05_Device_Selection/source.cpp
+++ b/Code_Exercises/Exercise_05_Device_Selection/source.cpp
@@ -12,5 +12,39 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("intel_gpu_device_selector", "device_selectors_solution") {
-  REQUIRE(true);
+  int a = 18, b = 24, r = 0;
+
+  try {
+    auto asyncHandler = [&](sycl::exception_list exceptionList) {
+      for (auto& e : exceptionList) {
+        std::rethrow_exception(e);
+      }
+    };
+
+
+    // Task: add a device selector to create this queue with an Intel GPU
+    auto defaultQueue = sycl::queue{asyncHandler};
+
+    {
+      auto bufA = sycl::buffer{&a, sycl::range{1}};
+      auto bufB = sycl::buffer{&b, sycl::range{1}};
+      auto bufR = sycl::buffer{&r, sycl::range{1}};
+
+      defaultQueue
+          .submit([&](sycl::handler& cgh) {
+            auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
+            auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
+            auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
+
+            cgh.single_task<scalar_add>([=]() { accR[0] = accA[0] + accB[0]; });
+          })
+          .wait();
+    }
+
+    defaultQueue.throw_asynchronous();
+  } catch (const sycl::exception& e) {
+    std::cout << "Exception caught: " << e.what() << std::endl;
+  }
+
+  REQUIRE(r == 42);
 }

--- a/Code_Exercises/Exercise_06_Vector_Add/source.cpp
+++ b/Code_Exercises/Exercise_06_Vector_Add/source.cpp
@@ -12,6 +12,21 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("vector_add", "vector_add_solution") {
+  constexpr size_t dataSize = 1024;
 
-  REQUIRE(true);
+  float a[dataSize], b[dataSize], r[dataSize];
+  for (int i = 0; i < dataSize; ++i) {
+    a[i] = static_cast<float>(i);
+    b[i] = static_cast<float>(i);
+    r[i] = 0.0f;
+  }
+
+  // Task: Compute r[i] = a[i] + b[i] in parallel on the SYCL device
+  for (int i = 0; i < dataSize; ++i) {
+    r[i] = a[i] + b[i];
+  }
+
+  for (int i = 0; i < dataSize; ++i) {
+    REQUIRE(r[i] == static_cast<float>(i) * 2.0f);
+  }
 }

--- a/Code_Exercises/Exercise_07_USM_Selector/README.md
+++ b/Code_Exercises/Exercise_07_USM_Selector/README.md
@@ -21,7 +21,7 @@ This can be querying for the `aspect::usm_device_allocations` aspect.
 ### 3.) Create a queue
 
 Once you have a device selector which will choose a device which supports USM
-create a `queue` using it to select it's device, remember to handle errors.
+create a `queue` using it to select its device, remember to handle errors.
 
 
 #### Build And Execution Hints

--- a/Code_Exercises/Exercise_07_USM_Selector/source.cpp
+++ b/Code_Exercises/Exercise_07_USM_Selector/source.cpp
@@ -13,5 +13,9 @@
 
 TEST_CASE("usm_selector", "usm_selector_source") {
 
+  // Task: create a queue to a device which supports USM allocations
+  // Remember to check for exceptions
+  auto usmQueue  = sycl::queue{};
+
   REQUIRE(true);
 }

--- a/Code_Exercises/Exercise_08_USM_Vector_Add/source.cpp
+++ b/Code_Exercises/Exercise_08_USM_Vector_Add/source.cpp
@@ -12,5 +12,22 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("usm_vector_add", "usm_vector_add_source") {
-  REQUIRE(true);
+  constexpr size_t dataSize = 1024;
+
+  float a[dataSize], b[dataSize], r[dataSize];
+  for (int i = 0; i < dataSize; ++i) {
+    a[i] = static_cast<float>(i);
+    b[i] = static_cast<float>(i);
+    r[i] = 0.0f;
+  }
+
+  // Task: Allocate the arrays in USM, and compute r[i] = a[i] + b[i] on the SYCL device
+  for (int i = 0; i < dataSize; ++i) {
+    r[i] = a[i] + b[i];
+  }
+
+
+  for (int i = 0; i < dataSize; ++i) {
+    REQUIRE(r[i] == i * 2);
+  }
 }

--- a/Code_Exercises/Exercise_09_Synchronization/source.cpp
+++ b/Code_Exercises/Exercise_09_Synchronization/source.cpp
@@ -12,5 +12,6 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("synchronization", "synchronization_source") {
+  // Use your code from Exercises 6 and 8 to start
   REQUIRE(true);
 }

--- a/Code_Exercises/Exercise_10_Managing_Dependencies/source.cpp
+++ b/Code_Exercises/Exercise_10_Managing_Dependencies/source.cpp
@@ -12,5 +12,40 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("managing_dependencies", "managing_dependencies_source") {
-  REQUIRE(true);
+  constexpr size_t dataSize = 1024;
+
+  int inA[dataSize], inB[dataSize], inC[dataSize], out[dataSize];
+  for (int i = 0; i < dataSize; ++i) {
+    inA[i] = static_cast<float>(i);
+    inB[i] = static_cast<float>(i);
+    inC[i] = static_cast<float>(i);
+    out[i] = 0.0f;
+  }
+
+  // Task: Run these kernels on the SYCL device, respecting the dependencies
+  // as shown in the README
+
+  // Kernel A
+  for (int i = 0; i < dataSize; ++i) {
+    inA[i] = inA[i] * 2.0f;
+  }
+
+  // Kernel B
+  for (int i = 0; i < dataSize; ++i) {
+    inB[i] += inA[i];
+  }
+
+  // Kernel C
+  for (int i = 0; i < dataSize; ++i) {
+    inC[i] -= inA[i];
+  }
+
+  // Kernel D
+  for (int i = 0; i < dataSize; ++i) {
+    out[i] = inB[i] + inC[i];
+  }
+
+  for (int i = 0; i < dataSize; ++i) {
+    REQUIRE(out[i] == i * 2.0f);
+  }
 }

--- a/Code_Exercises/Exercise_11_In_Order_Queue/source.cpp
+++ b/Code_Exercises/Exercise_11_In_Order_Queue/source.cpp
@@ -12,5 +12,6 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("in_order_queue", "in_order_queue_source") {
+  // Use the Exercise 10 solution to start
   REQUIRE(true);
 }

--- a/Code_Exercises/Exercise_12_Temporary_Data/source.cpp
+++ b/Code_Exercises/Exercise_12_Temporary_Data/source.cpp
@@ -12,5 +12,29 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("temporary_data", "temporary_data_source") {
-  REQUIRE(true);
+  constexpr size_t dataSize = 1024;
+
+  float in[dataSize], out[dataSize], tmp[dataSize];
+  for (int i = 0; i < dataSize; ++i) {
+    in[i] = static_cast<float>(i);
+    tmp[i] = 0.0f;
+    out[i] = 0.0f;
+  }
+
+  // Task: run these kernels on a SYCL device, minimising the memory transfers between the host and device
+
+  // Kernel A
+  for (int i = 0; i < dataSize; ++i) {
+    tmp[i] = in[i] * 8.0f;
+  }
+
+
+  // Kernel B
+  for (int i = 0; i < dataSize; ++i) {
+    out[i] = tmp[i] / 2.0f;
+  }
+
+  for (int i = 0; i < dataSize; ++i) {
+    REQUIRE(out[i] == i * 4.0f);
+  }
 }

--- a/Code_Exercises/Exercise_13_Load_Balancing/source.cpp
+++ b/Code_Exercises/Exercise_13_Load_Balancing/source.cpp
@@ -24,7 +24,8 @@ TEST_CASE("load_balancing", "load_balancing_source") {
     r[i] = 0.0f;
   }
 
-  // Task: run these two kernels on the SYCL device
+  // Task: split the total work across two distinct SYCL devices
+  // You might split the work as in the two loops below.
 
   // Vector add for first part
   for (int i = 0; i < dataSizeFirst; ++i) {

--- a/Code_Exercises/Exercise_13_Load_Balancing/source.cpp
+++ b/Code_Exercises/Exercise_13_Load_Balancing/source.cpp
@@ -12,5 +12,31 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("load_balancing", "load_balancing_source") {
-  REQUIRE(true);
+  constexpr size_t dataSize = 1024;
+  constexpr float ratio = 0.5f;
+  constexpr size_t dataSizeFirst = ratio * dataSize;
+  constexpr size_t dataSizeSecond = dataSize - dataSizeFirst;
+
+  float a[dataSize], b[dataSize], r[dataSize];
+  for (int i = 0; i < dataSize; ++i) {
+    a[i] = static_cast<float>(i);
+    b[i] = static_cast<float>(i);
+    r[i] = 0.0f;
+  }
+
+  // Task: run these two kernels on the SYCL device
+
+  // Vector add for first part
+  for (int i = 0; i < dataSizeFirst; ++i) {
+    r[i] = a[i] + b[i];
+  }
+
+  // Vector add for second part
+  for (int i = 0; i < dataSizeSecond; ++i) {
+    r[dataSizeFirst + i] = a[dataSizeFirst + i] + b[dataSizeFirst + i];
+  }
+
+  for (int i = 0; i < dataSize; ++i) {
+    REQUIRE(r[i] == static_cast<float>(i) * 2.0f);
+  }
 }

--- a/Code_Exercises/Exercise_14_ND_Range_Kernel/source.cpp
+++ b/Code_Exercises/Exercise_14_ND_Range_Kernel/source.cpp
@@ -12,5 +12,21 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("nd_range_kernel", "nd_range_kernel_source") {
-  REQUIRE(true);
+  constexpr size_t dataSize = 1024;
+
+  int a[dataSize], b[dataSize], r[dataSize];
+  for (int i = 0; i < dataSize; ++i) {
+    a[i] = i;
+    b[i] = i;
+    r[i] = 0;
+  }
+
+  // Task: parallelise the vector add kernel using nd_range
+  for (int i = 0; i < dataSize; ++i) {
+    r[i] = a[i] + b[i];
+  }
+
+  for (int i = 0; i < dataSize; ++i) {
+    REQUIRE(r[i] == i * 2);
+  }
 }

--- a/Code_Exercises/Exercise_16_Coalesced_Global_Memory/source.cpp
+++ b/Code_Exercises/Exercise_16_Coalesced_Global_Memory/source.cpp
@@ -12,5 +12,6 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("image_convolution_coalesced", "coalesced_global_memory_source") {
+  // Use your code from Exercise 15 to start
   REQUIRE(true);
 }

--- a/Code_Exercises/Exercise_17_Vectors/source.cpp
+++ b/Code_Exercises/Exercise_17_Vectors/source.cpp
@@ -12,5 +12,6 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("image_convolution_vectorized", "vectors_source") {
+  // Use your code from Exercise 16 to start
   REQUIRE(true);
 }

--- a/Code_Exercises/Exercise_18_Local_Memory_Tiling/source.cpp
+++ b/Code_Exercises/Exercise_18_Local_Memory_Tiling/source.cpp
@@ -12,5 +12,6 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("image_convolution_tiled", "local_memory_tiling_source") {
+  // Use your code from Exercise 17 to start
   REQUIRE(true);
 }

--- a/Code_Exercises/Exercise_19_Work_Group_Sizes/source.cpp
+++ b/Code_Exercises/Exercise_19_Work_Group_Sizes/source.cpp
@@ -12,5 +12,6 @@
 #include <catch2/catch.hpp>
 
 TEST_CASE("image_convolution_work_group_sizes", "work_group_sizes_source") {
+  // Use your code from Exercise 18 to start
   REQUIRE(true);
 }

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Pull Request so that they can be reviewed and merged in a timely manner.
 
 ### List of Contributors
 
-Codeplay Software Ltd., Heidelberg University, Intel, and Xilinx.
+Codeplay Software Ltd., Heidelberg University, Intel, Xilinx and University of Bristol.
 
 ## Supporting Organizations
 Abertay University, Universidad de Concepcion, TU Dresden, University of


### PR DESCRIPTION
This gives each Exercise a starting point, which is then used to
produce the sample solution. This means that you don't have to
come up with what each kernel does to complete the exercise, as
well as perform the designated task to use a particular part of
the SYCL API.