### PR TITLE
Updates & Fixes from recent training

### DIFF
--- a/Code_Exercises/Exercise_18_Local_Memory_Tiling/solution.cpp
+++ b/Code_Exercises/Exercise_18_Local_Memory_Tiling/solution.cpp
@@ -111,7 +111,7 @@ TEST_CASE("image_convolution_tiled", "local_memory_tiling_solution") {
                       }
                     }
 
-                    item.barrier();
+                    sycl::group_barrier(item.get_group());
 
                     auto sum = sycl::float4{0.0f, 0.0f, 0.0f, 0.0f};
 

--- a/Code_Exercises/Exercise_19_Work_Group_Sizes/solution.cpp
+++ b/Code_Exercises/Exercise_19_Work_Group_Sizes/solution.cpp
@@ -111,7 +111,7 @@ TEST_CASE("image_convolution_tiled", "local_memory_tiling_solution") {
                       }
                     }
 
-                    item.barrier();
+                    sycl::group_barrier(item.get_group());
 
                     auto sum = sycl::float4{0.0f, 0.0f, 0.0f, 0.0f};
 

--- a/Lesson_Materials/Lecture_01_What_is_SYCL/index.html
+++ b/Lesson_Materials/Lecture_01_What_is_SYCL/index.html
@@ -107,7 +107,7 @@
 						#### What is SYCL?
 					</div>
 					<div class="hbox" data-markdown>
-						SYCL is a **single source**, high-level, standard C++ programming model, that can target a range of heterogeneous platforms
+						SYCL is a ***single source***, high-level, standard C++ programming model, that can target a range of heterogeneous platforms
 					</div>
 					<div class="container">
 						<div class="col" data-markdown>
@@ -130,7 +130,7 @@
 						#### What is SYCL?
 					</div>
 					<div class="hbox" data-markdown>
-						SYCL is a single source, **high-level**, standard C++ programming model, that can target a range of heterogeneous platforms
+						SYCL is a single source, ***high-level***, standard C++ programming model, that can target a range of heterogeneous platforms
 					</div>
 					<div class="container">
 					<article class="main" data-markdown>
@@ -150,7 +150,7 @@
 						#### What is SYCL?
 					</div>
 				    <div class="hbox" data-markdown>
-				        SYCL is a single source, high-level **standard C++** programming model, that can target a range of heterogeneous platforms
+				        SYCL is a single source, high-level ***standard C++*** programming model, that can target a range of heterogeneous platforms
 					</div>
 					<div class="container">
 						<div class="col" data-markdown>

--- a/Lesson_Materials/Lecture_02_Enqueuing_a_Kernel/index.html
+++ b/Lesson_Materials/Lecture_02_Enqueuing_a_Kernel/index.html
@@ -325,7 +325,7 @@ gpuQueue.submit([&](handler &cgh){
 					<div class=container data-markdown>
 						* Must be defined using a C++ lambda or function object, they cannot be a function pointer or std::function.
 						* Must always capture or store members by-value.
-						* SYCL kernel functions declared with a lambda must be named using a forward declarable C++ type, declared in global scope.
+						* SYCL kernel functions declared with a lambda ~~must be named using a forward declarable C++ type, declared in global scope~~ can be anonymous since SYCL 2020!
 						* SYCL kernel function names follow C++ ODR rules, which means you cannot have two kernels with the same name.
 					</div>
 				</section>

--- a/Lesson_Materials/Lecture_14_ND_Range_Kernel/index.html
+++ b/Lesson_Materials/Lecture_14_ND_Range_Kernel/index.html
@@ -330,7 +330,7 @@ cgh.parallel_for&ltkernel&gt(nd_range&lt1&gt(<mark>range&lt1&gt(1024),
 					* Nested subscript operators can be called for each dimension taking a **size_t**
 					  * E.g. a 3-dimensional accessor: acc[x][y][z] = …
 					* A pointer to memory can be retrieved by calling **get_pointer**
-					  * This returns a **multi_ptr**, which is a wrapper class for pointers to the memory in the relevant memory space
+					  * This returns a raw pointer to the data
 					</div>
 				</section>
 				<!--Slide 23-->

--- a/Lesson_Materials/Lecture_16_Coalesced_Global_Memory/index.html
+++ b/Lesson_Materials/Lecture_16_Coalesced_Global_Memory/index.html
@@ -138,7 +138,7 @@
 						#### Row-major vs Column-major
 					</div>
 					<div class="container" data-markdown>
-						* Coalescing global memory access is particularly important when wording in multiple dimensions.
+						* Coalescing global memory access is particularly important when working in multiple dimensions.
 						* This is because when doing so you have to convert from a position in 2d space to a linear memory space.
 						* There are two ways to do this; generally referred to as row-major and column-major.
 					</div>

--- a/Lesson_Materials/Lecture_19_Work_Group_Sizes/index.html
+++ b/Lesson_Materials/Lecture_19_Work_Group_Sizes/index.html
@@ -60,7 +60,6 @@
 				<!--Slide 2-->
 				<section class="hbox" data-markdown>
 					## Learning Objectives
-					* Learn about using computecpp_info
 					* Learn about compute and memory bound algorithms
 					* Learn about optimizing for occupancy
 					* Learn about optimizing for throughput


### PR DESCRIPTION
While preparing & delivering this material recently, we encountered some out-of-date info & typos which are addressed here.

- Replace deprecated `item.barrier()`
- Anonymous lambda don't need to be forward-declared since SYCL 2020
- `get_pointer()` now returns a raw pointer, not `multi_ptr` (incorrectly described as get_native() in commit msg)
- Remove ref to `computecpp_info` to maintain implementation-agnosticism
- Minor formatting & typos