### PR TITLE
Replace buffer.get_access with sycl::accessor ctor

### DIFF
--- a/Code_Exercises/Exercise_06_Vector_Add/README.md
+++ b/Code_Exercises/Exercise_06_Vector_Add/README.md
@@ -22,7 +22,6 @@ Remember to ensure the `range` provided to the buffer is the size of the arrays.
 ### 3. ) Create accessors
 
 Create `accessor`s to each of the `buffer`s within the command group function.
-The simplest way to do this is to call `get_access` on the `buffer`s.
 
 ### 4. ) Write the kernel function
 

--- a/Code_Exercises/Exercise_06_Vector_Add/solution.cpp
+++ b/Code_Exercises/Exercise_06_Vector_Add/solution.cpp
@@ -44,9 +44,9 @@ TEST_CASE("vector_add", "vector_add_solution") {
 
     defaultQueue
         .submit([&](sycl::handler& cgh) {
-          auto accA = bufA.get_access<sycl::access::mode::read>(cgh);
-          auto accB = bufB.get_access<sycl::access::mode::read>(cgh);
-          auto accR = bufR.get_access<sycl::access::mode::write>(cgh);
+          sycl::accessor accA{bufA, cgh, sycl::read_only};
+          sycl::accessor accB{bufB, cgh, sycl::read_only};
+          sycl::accessor accR{bufR, cgh, sycl::write_only};
 
           cgh.parallel_for<vector_add>(
               sycl::range{dataSize},

--- a/Code_Exercises/Exercise_10_Managing_Dependencies/solution.cpp
+++ b/Code_Exercises/Exercise_10_Managing_Dependencies/solution.cpp
@@ -63,7 +63,7 @@ TEST_CASE("buffer_accessor_diamond", "managing_dependencies_solution") {
     auto bufOut = sycl::buffer{out, sycl::range{dataSize}};
 
     defaultQueue.submit([&](sycl::handler& cgh) {
-      auto acc = bufInA.get_access<sycl::access::mode::read_write>(cgh);
+      sycl::accessor acc{bufInA, cgh, sycl::read_write};
 
       cgh.parallel_for<kernel_a_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
         acc[idx] = acc[idx] * 2.0f;
@@ -71,8 +71,8 @@ TEST_CASE("buffer_accessor_diamond", "managing_dependencies_solution") {
     });
 
     defaultQueue.submit([&](sycl::handler& cgh) {
-      auto accIn = bufInA.get_access<sycl::access::mode::read>(cgh);
-      auto accOut = bufInB.get_access<sycl::access::mode::write>(cgh);
+      sycl::accessor accIn{bufInA, cgh, sycl::read_only};
+      sycl::accessor accOut{bufInB, cgh, sycl::write_only};
 
       cgh.parallel_for<kernel_b_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
         accOut[idx] += accIn[idx];
@@ -80,8 +80,8 @@ TEST_CASE("buffer_accessor_diamond", "managing_dependencies_solution") {
     });
 
     defaultQueue.submit([&](sycl::handler& cgh) {
-      auto accIn = bufInA.get_access<sycl::access::mode::read>(cgh);
-      auto accOut = bufInC.get_access<sycl::access::mode::write>(cgh);
+      sycl::accessor accIn{bufInA, cgh, sycl::read_only};
+      sycl::accessor accOut{bufInC, cgh, sycl::write_only};
 
       cgh.parallel_for<kernel_c_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
         accOut[idx] -= accIn[idx];
@@ -89,9 +89,9 @@ TEST_CASE("buffer_accessor_diamond", "managing_dependencies_solution") {
     });
 
     defaultQueue.submit([&](sycl::handler& cgh) {
-      auto accInA = bufInB.get_access<sycl::access::mode::read>(cgh);
-      auto accInB = bufInC.get_access<sycl::access::mode::read>(cgh);
-      auto accOut = bufOut.get_access<sycl::access::mode::write>(cgh);
+      sycl::accessor accInA{bufInB, cgh, sycl::read_only};
+      sycl::accessor accInB{bufInC, cgh, sycl::read_only};
+      sycl::accessor accOut{bufOut, cgh, sycl::write_only};
 
       cgh.parallel_for<kernel_d_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
         accOut[idx] = accInA[idx] + accInB[idx];

--- a/Code_Exercises/Exercise_11_In_Order_Queue/solution.cpp
+++ b/Code_Exercises/Exercise_11_In_Order_Queue/solution.cpp
@@ -67,7 +67,7 @@ TEST_CASE("buffer_accessor_in_order_queue", "in_order_queue_solution") {
     auto bufOut = sycl::buffer{out, sycl::range{dataSize}};
 
     inOrderQueue.submit([&](sycl::handler& cgh) {
-      auto acc = bufInA.get_access<sycl::access::mode::read_write>(cgh);
+      sycl::accessor acc{bufInA, cgh, sycl::read_write};
 
       cgh.parallel_for<kernel_a_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
         acc[idx] = acc[idx] * 2.0f;
@@ -75,8 +75,8 @@ TEST_CASE("buffer_accessor_in_order_queue", "in_order_queue_solution") {
     });
 
     inOrderQueue.submit([&](sycl::handler& cgh) {
-      auto accIn = bufInA.get_access<sycl::access::mode::read>(cgh);
-      auto accOut = bufInB.get_access<sycl::access::mode::write>(cgh);
+      sycl::accessor accIn{bufInA, cgh, sycl::read_only};
+      sycl::accessor accOut{bufInB, cgh, sycl::write_only};
 
       cgh.parallel_for<kernel_b_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
         accOut[idx] += accIn[idx];
@@ -84,8 +84,8 @@ TEST_CASE("buffer_accessor_in_order_queue", "in_order_queue_solution") {
     });
 
     inOrderQueue.submit([&](sycl::handler& cgh) {
-      auto accIn = bufInA.get_access<sycl::access::mode::read>(cgh);
-      auto accOut = bufInC.get_access<sycl::access::mode::write>(cgh);
+      sycl::accessor accIn{bufInA, cgh, sycl::read_only};
+      sycl::accessor accOut{bufInC, cgh, sycl::write_only};
 
       cgh.parallel_for<kernel_c_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
         accOut[idx] -= accIn[idx];
@@ -93,9 +93,9 @@ TEST_CASE("buffer_accessor_in_order_queue", "in_order_queue_solution") {
     });
 
     inOrderQueue.submit([&](sycl::handler& cgh) {
-      auto accInA = bufInB.get_access<sycl::access::mode::read>(cgh);
-      auto accInB = bufInC.get_access<sycl::access::mode::read>(cgh);
-      auto accOut = bufOut.get_access<sycl::access::mode::write>(cgh);
+      sycl::accessor accInA{bufInB, cgh, sycl::read_only};
+      sycl::accessor accInB{bufInC, cgh, sycl::read_only};
+      sycl::accessor accOut{bufOut, cgh, sycl::write_only};
 
       cgh.parallel_for<kernel_d_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
         accOut[idx] = accInA[idx] + accInB[idx];

--- a/Code_Exercises/Exercise_12_Temporary_Data/solution.cpp
+++ b/Code_Exercises/Exercise_12_Temporary_Data/solution.cpp
@@ -61,8 +61,8 @@ TEST_CASE("buffer_accessor_temporary_data", "temporary_data_solution") {
     bufOut.set_final_data(out);
 
     gpuQueue.submit([&](sycl::handler& cgh) {
-      auto accIn = bufIn.get_access<sycl::access::mode::read>(cgh);
-      auto accOut = bufInt.get_access<sycl::access::mode::write>(cgh);
+      sycl::accessor accIn{bufIn, cgh, sycl::read_only};
+      sycl::accessor accOut{bufInt, cgh, sycl::write_only};
 
       cgh.parallel_for<kernel_a_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
         accOut[idx] = accIn[idx] * 8.0f;
@@ -70,8 +70,8 @@ TEST_CASE("buffer_accessor_temporary_data", "temporary_data_solution") {
     });
 
     gpuQueue.submit([&](sycl::handler& cgh) {
-      auto accIn = bufInt.get_access<sycl::access::mode::read>(cgh);
-      auto accOut = bufOut.get_access<sycl::access::mode::write>(cgh);
+      sycl::accessor accIn{bufInt, cgh, sycl::read_only};
+      sycl::accessor accOut{bufOut, cgh, sycl::write_only};
 
       cgh.parallel_for<kernel_b_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
         accOut[idx] = accIn[idx] / 2.0f;

--- a/Code_Exercises/Exercise_13_Load_Balancing/solution.cpp
+++ b/Code_Exercises/Exercise_13_Load_Balancing/solution.cpp
@@ -101,9 +101,9 @@ TEST_CASE("load_balancing", "load_balancing_solution") {
       sycl::buffer{r + dataSizeFirst, sycl::range{dataSizeSecond}};
 
     Q1.submit([&](sycl::handler& cgh) {
-        auto accA = bufFirstA.get_access<sycl::access::mode::read>(cgh);
-        auto accB = bufFirstB.get_access<sycl::access::mode::read>(cgh);
-        auto accR = bufFirstR.get_access<sycl::access::mode::write>(cgh);
+        sycl::accessor accA{bufFirstA, cgh, sycl::read_only};
+        sycl::accessor accB{bufFirstB, cgh, sycl::read_only};
+        sycl::accessor accR{bufFirstR, cgh, sycl::write_only};
 
         cgh.parallel_for<vector_add_first>(
             sycl::range{dataSizeFirst},
@@ -111,9 +111,9 @@ TEST_CASE("load_balancing", "load_balancing_solution") {
         });
 
     Q2.submit([&](sycl::handler& cgh) {
-        auto accA = bufSecondA.get_access<sycl::access::mode::read>(cgh);
-        auto accB = bufSecondB.get_access<sycl::access::mode::read>(cgh);
-        auto accR = bufSecondR.get_access<sycl::access::mode::write>(cgh);
+        sycl::accessor accA{bufSecondA, cgh, sycl::read_only};
+        sycl::accessor accB{bufSecondB, cgh, sycl::read_only};
+        sycl::accessor accR{bufSecondR, cgh, sycl::write_only};
 
         cgh.parallel_for<vector_add_second>(
             sycl::range{dataSizeSecond},

--- a/Code_Exercises/Exercise_14_ND_Range_Kernel/solution.cpp
+++ b/Code_Exercises/Exercise_14_ND_Range_Kernel/solution.cpp
@@ -44,9 +44,9 @@ TEST_CASE("range_kernel_with_item", "nd_range_kernel_solution") {
     auto bufR = sycl::buffer{r, sycl::range{dataSize}};
 
     gpuQueue.submit([&](sycl::handler& cgh) {
-      auto accA = bufA.get_access<sycl::access::mode::read>(cgh);
-      auto accB = bufB.get_access<sycl::access::mode::read>(cgh);
-      auto accR = bufR.get_access<sycl::access::mode::write>(cgh);
+      sycl::accessor accA{bufA, cgh, sycl::read_only};
+      sycl::accessor accB{bufB, cgh, sycl::read_only};
+      sycl::accessor accR{bufR, cgh, sycl::write_only};
 
       cgh.parallel_for<vector_add_1>(
           sycl::range{dataSize}, [=](sycl::item<1> itm) {
@@ -90,9 +90,9 @@ TEST_CASE("nd_range_kernel", "nd_range_kernel_solution") {
     auto bufR = sycl::buffer{r, sycl::range{dataSize}};
 
     gpuQueue.submit([&](sycl::handler& cgh) {
-      auto accA = bufA.get_access<sycl::access::mode::read_write>(cgh);
-      auto accB = bufB.get_access<sycl::access::mode::read_write>(cgh);
-      auto accR = bufR.get_access<sycl::access::mode::read_write>(cgh);
+      sycl::accessor accA{bufA, cgh, sycl::read_write};
+      sycl::accessor accB{bufB, cgh, sycl::read_write};
+      sycl::accessor accR{bufR, cgh, sycl::read_write};
 
       auto ndRange =
           sycl::nd_range{sycl::range{dataSize}, sycl::range{workGroupSize}};

--- a/Code_Exercises/Exercise_15_Image_Convolution/reference.cpp
+++ b/Code_Exercises/Exercise_15_Image_Convolution/reference.cpp
@@ -77,11 +77,9 @@ TEST_CASE("image_convolution_naive", "image_convolution_reference") {
       util::benchmark(
           [&]() {
             myQueue.submit([&](sycl::handler& cgh) {
-              auto inputAcc = inBuf.get_access<sycl::access::mode::read>(cgh);
-              auto outputAcc =
-                  outBuf.get_access<sycl::access::mode::write>(cgh);
-              auto filterAcc =
-                  filterBuf.get_access<sycl::access::mode::read>(cgh);
+              sycl::accessor inputAcc{inBuf, cgh, sycl::read_only};
+              sycl::accessor outputAcc{outBuf, cgh, sycl::write_only};
+              sycl::accessor filterAcc{filterBuf, cgh, sycl::read_only};
 
               cgh.parallel_for<image_convolution>(
                   ndRange, [=](sycl::nd_item<2> item) {

--- a/Code_Exercises/Exercise_16_Coalesced_Global_Memory/solution.cpp
+++ b/Code_Exercises/Exercise_16_Coalesced_Global_Memory/solution.cpp
@@ -77,11 +77,9 @@ TEST_CASE("image_convolution_coalesced", "coalesced_global_memory_solution") {
       util::benchmark(
           [&]() {
             myQueue.submit([&](sycl::handler& cgh) {
-              auto inputAcc = inBuf.get_access<sycl::access::mode::read>(cgh);
-              auto outputAcc =
-                  outBuf.get_access<sycl::access::mode::write>(cgh);
-              auto filterAcc =
-                  filterBuf.get_access<sycl::access::mode::read>(cgh);
+              sycl::accessor inputAcc{inBuf, cgh, sycl::read_only};
+              sycl::accessor outputAcc{outBuf, cgh, sycl::write_only};
+              sycl::accessor filterAcc{filterBuf, cgh, sycl::read_only};
 
               cgh.parallel_for<image_convolution>(
                   ndRange, [=](sycl::nd_item<2> item) {

--- a/Code_Exercises/Exercise_17_Vectors/solution.cpp
+++ b/Code_Exercises/Exercise_17_Vectors/solution.cpp
@@ -85,12 +85,9 @@ TEST_CASE("image_convolution_vectorized", "vectors_solution") {
       util::benchmark(
           [&]() {
             myQueue.submit([&](sycl::handler& cgh) {
-              auto inputAcc =
-                  inBufVec.get_access<sycl::access::mode::read>(cgh);
-              auto outputAcc =
-                  outBufVec.get_access<sycl::access::mode::write>(cgh);
-              auto filterAcc =
-                  filterBufVec.get_access<sycl::access::mode::read>(cgh);
+              sycl::accessor inputAcc{inBufVec, cgh, sycl::read_only};
+              sycl::accessor outputAcc{outBufVec, cgh, sycl::write_only};
+              sycl::accessor filterAcc{filterBufVec, cgh, sycl::read_only};
 
               cgh.parallel_for<image_convolution>(
                   ndRange, [=](sycl::nd_item<2> item) {

--- a/Code_Exercises/Exercise_18_Local_Memory_Tiling/solution.cpp
+++ b/Code_Exercises/Exercise_18_Local_Memory_Tiling/solution.cpp
@@ -83,12 +83,9 @@ TEST_CASE("image_convolution_tiled", "local_memory_tiling_solution") {
       util::benchmark(
           [&] {
             myQueue.submit([&](sycl::handler &cgh) {
-              auto inputAcc =
-                  inBufVec.get_access<sycl::access::mode::read>(cgh);
-              auto outputAcc =
-                  outBufVec.get_access<sycl::access::mode::write>(cgh);
-              auto filterAcc =
-                  filterBufVec.get_access<sycl::access::mode::read>(cgh);
+              sycl::accessor inputAcc{inBufVec, cgh, sycl::read_only};
+              sycl::accessor outputAcc{outBufVec, cgh, sycl::write_only};
+              sycl::accessor filterAcc{filterBufVec, cgh, sycl::read_only};
 
               auto scratchpad = sycl::accessor<sycl::float4, 2,
                                                sycl::access::mode::read_write,

--- a/Code_Exercises/Exercise_19_Work_Group_Sizes/solution.cpp
+++ b/Code_Exercises/Exercise_19_Work_Group_Sizes/solution.cpp
@@ -83,12 +83,9 @@ TEST_CASE("image_convolution_tiled", "local_memory_tiling_solution") {
       util::benchmark(
           [&] {
             myQueue.submit([&](sycl::handler &cgh) {
-              auto inputAcc =
-                  inBufVec.get_access<sycl::access::mode::read>(cgh);
-              auto outputAcc =
-                  outBufVec.get_access<sycl::access::mode::write>(cgh);
-              auto filterAcc =
-                  filterBufVec.get_access<sycl::access::mode::read>(cgh);
+              sycl::accessor inputAcc{inBufVec, cgh, sycl::read_only};
+              sycl::accessor outputAcc{outBufVec, cgh, sycl::write_only};
+              sycl::accessor filterAcc{filterBufVec, cgh, sycl::read_only};
 
               auto scratchpad = sycl::accessor<sycl::float4, 2,
                                                sycl::access::mode::read_write,

--- a/Lesson_Materials/Lecture_10_Data_and_Dependencies/index.html
+++ b/Lesson_Materials/Lecture_10_Data_and_Dependencies/index.html
@@ -157,7 +157,7 @@ gpuQueue.submit([&](sycl::handler &cgh) {
 });
 
 gpuQueue.submit([&](sycl::handler &cgh) {
-  auto acc = buf.get_access(cgh);
+  sycl::accessor acc{buf, cgh};
 
   cgh.parallel_for&lt;kernel_b&gt;(sycl::range{1024},
     [=](sycl::id&lt;1&gt; idx) {
@@ -195,7 +195,7 @@ gpuQueue.submit([&](sycl::handler &cgh) {
 });
 
 gpuQueue.submit([&](sycl::handler &cgh) {
-  auto acc = buf.get_access(cgh);
+  sycl::accessor acc {buf, cgh};
 
   cgh.parallel_for&lt;kernel_b&gt;(sycl::range{1024},
     [=](sycl::id&lt;1&gt; idx) {
@@ -225,7 +225,7 @@ gpuQueue.wait();
 sycl::buffer buf {data, sycl::range{1024}};
 
 gpuQueue.submit([&](sycl::handler &cgh) {
-  <mark>sycl::accessor acc {buf, cgh};</mark>
+  <mark>sycl::accessor acc{buf, cgh};</mark>
 
   cgh.parallel_for&lt;my_kernel&gt;(sycl::range{1024},
     [=](sycl::id&lt;1&gt; idx) {
@@ -234,7 +234,7 @@ gpuQueue.submit([&](sycl::handler &cgh) {
 });
 
 gpuQueue.submit([&](sycl::handler &cgh) {
-  <mark>auto acc = buf.get_access(cgh);</mark>
+  <mark>sycl::accessor acc{buf, cgh};</mark>
 
   cgh.parallel_for&lt;my_kernel&gt;(sycl::range{1024},
     [=](sycl::id&lt;1&gt; idx) {
@@ -272,7 +272,7 @@ gpuQueue.submit([&](sycl::handler &cgh) {
 });
 
 gpuQueue.submit([&](sycl::handler &cgh) {
-  auto acc = buf.get_access(<mark>cgh</mark>);
+  sycl::accessor acc {buf, <mark>cgh</mark>};
 
   cgh.parallel_for&lt;my_kernel&gt;(sycl::range{1024},
     [=](sycl::id&lt;1&gt; idx) {
@@ -424,7 +424,7 @@ sycl::buffer bufA {dataA, sycl::range{1024}};
 sycl::buffer bufB {dataB, sycl::range{1024}};
 
 gpuQueue.submit([&](sycl::handler &cgh) {
-  <mark>auto accA = bufA.get_access(cgh);</mark>
+  <mark>sycl::accessor accA {bufA, cgh};</mark>
 
   cgh.parallel_for&lt;kernel_a&gt;(sycl::range{1024},
     [=](sycl::id&lt;1&gt; idx) {
@@ -433,7 +433,7 @@ gpuQueue.submit([&](sycl::handler &cgh) {
 });
 
 gpuQueue.submit([&](sycl::handler &cgh) {
-  <mark>auto accB = bufB.get_access(cgh);</mark>
+  <mark>sycl::accessor accB {bufB, cgh};</mark>
 
   cgh.parallel_for&lt;kernel_b&gt;(sycl::range{1024},
     [=](sycl::id&lt;1&gt; idx) {

--- a/Lesson_Materials/Lecture_11_In_Order_Queue/index.html
+++ b/Lesson_Materials/Lecture_11_In_Order_Queue/index.html
@@ -121,7 +121,7 @@ auto inOrderQueue = sycl::queue{gpu_selector{},
 buf = sycl::buffer(data, sycl::range{1024});
 
 inOrderQueue.submit([&](sycl::handler &cgh){
-  auto acc = buf.get_access(cgh);
+  sycl::accessor acc{buf, cgh};
       
   cgh.parallel_for&lt;kernel_a&gt;(sycl::range{1024},
     [=](sycl::id&lt;1&gt; idx){
@@ -130,7 +130,7 @@ inOrderQueue.submit([&](sycl::handler &cgh){
 });
 
 inOrderQueue.submit([&](sycl::handler &cgh){
-  auto acc = buf.get_access(cgh);
+  sycl::accessor acc{buf, cgh};
 		
   cgh.parallel_for&lt;kernel_b&gt;(sycl::range{1024},
     [=](sycl::id&lt;1&gt; idx){

--- a/Lesson_Materials/Lecture_14_ND_Range_Kernel/index.html
+++ b/Lesson_Materials/Lecture_14_ND_Range_Kernel/index.html
@@ -346,9 +346,9 @@ buffer&ltfloat, 1&gt bufB(dB.data(), range&lt1&gt(dB.size()));
 buffer&ltfloat, 1&gt bufO(dO.data(), range&lt1&gt(dO.size()));
 
 gpuQueue.submit([&](handler &cgh){
-  auto inA = bufA.get_access&ltaccess::mode::read&gt(cgh);
-  auto inB = bufB.get_access&ltaccess::mode::read&gt(cgh);
-  auto out = bufO.get_access&ltaccess::mode::write&gt(cgh);
+  sycl::accessor inA{bufA, cgh, sycl::read_only};
+  sycl::accessor inB{bufB, cgh, sycl::read_only};
+  sycl::accessor out{bufO, cgh, sycl::write_only};
   cgh.parallel_for&ltadd&gt(range&lt1&gt(dA.size()), 
     [=](id&lt1&gt i){ 
     <mark>out[i] = inA[i] + inB[i];</mark>
@@ -376,9 +376,9 @@ buffer&ltfloat, 1&gt bufB(dB.data(), range&lt1&gt(dB.size()));
 buffer&ltfloat, 1&gt bufO(dO.data(), range&lt1&gt(dO.size()));
 
 gpuQueue.submit([&](handler &cgh){
-  auto inA = bufA.get_access&ltaccess::mode::read&gt(cgh);
-  auto inB = bufB.get_access&ltaccess::mode::read&gt(cgh);
-  auto out = bufO.get_access&ltaccess::mode::write&gt(cgh);
+  sycl::accessor inA{bufA, cgh, sycl::read_only};
+  sycl::accessor inB{bufB, cgh, sycl::read_only};
+  sycl::accessor out{bufO, cgh, sycl::write_only};
   cgh.parallel_for&ltadd&gt(rng, [=](id&lt3&gt i){
     <mark>auto ptrA = inA.get_pointer();</mark>
     <mark>auto ptrB = inB.get_pointer();</mark>


### PR DESCRIPTION
Since CTAD, it's a lot easier to just construct accessors instead of calling `get_access`, so I have updated this in all code exercises & lectures.