### PR TITLE
Transpose `id` in ND-Range lesson materials

### DIFF
--- a/Lesson_Materials/Lecture_04_ND_Range_Kernel/index.html
+++ b/Lesson_Materials/Lecture_04_ND_Range_Kernel/index.html
@@ -140,11 +140,11 @@
 							* Each invocation knows which work-item it is on and can query certain information about its position in the nd-range
 							* Each work-item has the following:
 							  * **Global range**: {12, 12}
-							  * **Global id**: {6, 5}
+							  * **Global id**: {5, 6}
 							  * **Group range**: {3, 3}
 							  * **Group id**: {1, 1}
 							  * **Local range**: {4, 4}
-							  * **Local id**: {2, 1}
+							  * **Local id**: {1, 2}
 						</div>
 						<div class="col" data-markdown>
 							![ND-Range](../common-revealjs/images/ndrange-example-work-item.png "ND-Range")


### PR DESCRIPTION
<img src="https://user-images.githubusercontent.com/15614155/170003231-3c4f10fb-b934-4403-b157-a4fdd255c276.png" width="600">

For the `global id` to be `{6, 5}` one would have to assume that `global_range[0]` is the number of columns and `global_range[1]` is the number of rows in a 2d space. 

This PR fixes `global id` and `local id` in the slides considering "row major" layout as described in https://www.khronos.org/registry/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:multi-dim-linearization.


Figure 4-4. (Data Parallel C++) is a good example of how to show these concepts more explicitly. 
<img src="https://user-images.githubusercontent.com/15614155/170006046-c68fcb37-bdfe-44b4-bf92-90c54ab2fd64.png" width="400">
