### PR TITLE
Fix some issues with the DPC++ build hints

### DIFF
--- a/Code_Exercises/Exercise_01_Compiling_with_SYCL/README.md
+++ b/Code_Exercises/Exercise_01_Compiling_with_SYCL/README.md
@@ -87,7 +87,7 @@ and invoke the executable.
 
 For For DPC++ (using the Intel DevCloud):
 ```sh
-clang++ -fsycl -o sycl-ex-1 -I../External/Catch2/single_include ../Code_Exercises/Exercise_01_compiling_with_SYCL/source.cpp
+icpx -fsycl -o sycl-ex-1 -I../External/Catch2/single_include ../Code_Exercises/Exercise_01_compiling_with_SYCL/source.cpp
 ```
 In Intel DevCloud, to run computational applications, you will submit jobs to a queue for execution on compute nodes,
 especially some features like longer walltime and multi-node computation is only abvailable through the job queue.

--- a/Code_Exercises/Exercise_01_Compiling_with_SYCL/README.md
+++ b/Code_Exercises/Exercise_01_Compiling_with_SYCL/README.md
@@ -85,7 +85,7 @@ and invoke the executable.
 
 #### Build And Execution Hints
 
-For For DPC++ (using the Intel DevCloud):
+For DPC++ (using the Intel DevCloud):
 ```sh
 icpx -fsycl -o sycl-ex-1 -I../External/Catch2/single_include ../Code_Exercises/Exercise_01_compiling_with_SYCL/source.cpp
 ```

--- a/Code_Exercises/Exercise_02_Hello_World/README.md
+++ b/Code_Exercises/Exercise_02_Hello_World/README.md
@@ -50,7 +50,7 @@ Then use the stream you constructed within the SYCL kernel function to print
 
 For For DPC++ (using the Intel DevCloud):
 ```sh
-clang++ -fsycl -o sycl-ex-2 -I../External/Catch2/single_include ../Code_Exercises/Exercise_02_Hello_World/source.cpp
+icpx -fsycl -o sycl-ex-2 -I../External/Catch2/single_include ../Code_Exercises/Exercise_02_Hello_World/source.cpp
 ```
 In Intel DevCloud, to run computational applications, you will submit jobs to a queue for execution on compute nodes,
 especially some features like longer walltime and multi-node computation is only abvailable through the job queue.

--- a/Code_Exercises/Exercise_02_Hello_World/README.md
+++ b/Code_Exercises/Exercise_02_Hello_World/README.md
@@ -48,7 +48,7 @@ Then use the stream you constructed within the SYCL kernel function to print
 
 #### Build And Execution Hints
 
-For For DPC++ (using the Intel DevCloud):
+For DPC++ (using the Intel DevCloud):
 ```sh
 icpx -fsycl -o sycl-ex-2 -I../External/Catch2/single_include ../Code_Exercises/Exercise_02_Hello_World/source.cpp
 ```

--- a/Code_Exercises/Exercise_03_Scalar_Add/README.md
+++ b/Code_Exercises/Exercise_03_Scalar_Add/README.md
@@ -48,7 +48,7 @@ initializing it with just a `range` and no host pointer.
 
 For For DPC++ (using the Intel DevCloud):
 ```sh
-clang++ -fsycl -o sycl-ex-3 -I../External/Catch2/single_include ../Code_Exercises/Exercise_03_Scalar_Add/source.cpp
+icpx -fsycl -o sycl-ex-3 -I../External/Catch2/single_include ../Code_Exercises/Exercise_03_Scalar_Add/source.cpp
 ./sycl-ex-3
 ```
 In Intel DevCloud, to run computational applications, you will submit jobs to a queue for execution on compute nodes,

--- a/Code_Exercises/Exercise_03_Scalar_Add/README.md
+++ b/Code_Exercises/Exercise_03_Scalar_Add/README.md
@@ -46,7 +46,7 @@ initializing it with just a `range` and no host pointer.
 
 #### Build And Execution Hints
 
-For For DPC++ (using the Intel DevCloud):
+For DPC++ (using the Intel DevCloud):
 ```sh
 icpx -fsycl -o sycl-ex-3 -I../External/Catch2/single_include ../Code_Exercises/Exercise_03_Scalar_Add/source.cpp
 ./sycl-ex-3

--- a/Code_Exercises/Exercise_04_Handling_Errors/README.md
+++ b/Code_Exercises/Exercise_04_Handling_Errors/README.md
@@ -31,7 +31,7 @@ exceptions to be caught by the surrounding try-catch block.
 
 For For DPC++ (using the Intel DevCloud):
 ```sh
-clang++ -fsycl -o sycl-ex-4 -I../External/Catch2/single_include ../Code_Exercises/Exercise_04_Handling_Errors/source.cpp
+icpx -fsycl -o sycl-ex-4 -I../External/Catch2/single_include ../Code_Exercises/Exercise_04_Handling_Errors/source.cpp
 ```
 In Intel DevCloud, to run computational applications, you will submit jobs to a queue for execution on compute nodes,
 especially some features like longer walltime and multi-node computation is only abvailable through the job queue.

--- a/Code_Exercises/Exercise_04_Handling_Errors/README.md
+++ b/Code_Exercises/Exercise_04_Handling_Errors/README.md
@@ -29,7 +29,7 @@ exceptions to be caught by the surrounding try-catch block.
 
 #### Build And Execution Hints
 
-For For DPC++ (using the Intel DevCloud):
+For DPC++ (using the Intel DevCloud):
 ```sh
 icpx -fsycl -o sycl-ex-4 -I../External/Catch2/single_include ../Code_Exercises/Exercise_04_Handling_Errors/source.cpp
 ```

--- a/Code_Exercises/Exercise_05_Device_Selection/README.md
+++ b/Code_Exercises/Exercise_05_Device_Selection/README.md
@@ -119,7 +119,7 @@ and invoke the executable.
 
 #### Build And Execution Hints
 
-For For DPC++ (using the Intel DevCloud):
+For DPC++ (using the Intel DevCloud):
 ```sh
 icpx -fsycl -o sycl-ex-5 -I../External/Catch2/single_include ../Code_Exercises/Exercise_05_Device_Selection/source.cpp
 ```

--- a/Code_Exercises/Exercise_05_Device_Selection/README.md
+++ b/Code_Exercises/Exercise_05_Device_Selection/README.md
@@ -121,7 +121,7 @@ and invoke the executable.
 
 For For DPC++ (using the Intel DevCloud):
 ```sh
-clang++ -fsycl -o sycl-ex-5 -I../External/Catch2/single_include ../Code_Exercises/Exercise_05_Device_Selection/source.cpp
+icpx -fsycl -o sycl-ex-5 -I../External/Catch2/single_include ../Code_Exercises/Exercise_05_Device_Selection/source.cpp
 ```
 In Intel DevCloud, to run computational applications, you will submit jobs to a queue for execution on compute nodes,
 especially some features like longer walltime and multi-node computation is only abvailable through the job queue.

--- a/Code_Exercises/Exercise_06_Vector_Add/README.md
+++ b/Code_Exercises/Exercise_06_Vector_Add/README.md
@@ -104,7 +104,7 @@ and invoke the executable.
 
 #### Build And Execution Hints
 
-For For DPC++ (using the Intel DevCloud):
+For DPC++ (using the Intel DevCloud):
 ```sh
 icpx -fsycl -o sycl-ex-6 -I../External/Catch2/single_include ../Code_Exercises/Exercise_06_Vector_Add/source.cpp
 ```

--- a/Code_Exercises/Exercise_06_Vector_Add/README.md
+++ b/Code_Exercises/Exercise_06_Vector_Add/README.md
@@ -106,7 +106,7 @@ and invoke the executable.
 
 For For DPC++ (using the Intel DevCloud):
 ```sh
-clang++ -fsycl -o sycl-ex-6 -I../External/Catch2/single_include ../Code_Exercises/Exercise_06_Vector_Add/source.cpp
+icpx -fsycl -o sycl-ex-6 -I../External/Catch2/single_include ../Code_Exercises/Exercise_06_Vector_Add/source.cpp
 ```
 In Intel DevCloud, to run computational applications, you will submit jobs to a queue for execution on compute nodes,
 especially some features like longer walltime and multi-node computation is only abvailable through the job queue.

--- a/Code_Exercises/Exercise_07_USM_Selector/README.md
+++ b/Code_Exercises/Exercise_07_USM_Selector/README.md
@@ -28,7 +28,7 @@ create a `queue` using it to select its device, remember to handle errors.
 
 For For DPC++ (using the Intel DevCloud):
 ```sh
-clang++ -fsycl -o sycl-ex-7 -I../External/Catch2/single_include ../Code_Exercises/Exercise_07_USM_Selector/source.cpp
+icpx -fsycl -o sycl-ex-7 -I../External/Catch2/single_include ../Code_Exercises/Exercise_07_USM_Selector/source.cpp
 ```
 In Intel DevCloud, to run computational applications, you will submit jobs to a queue for execution on compute nodes,
 especially some features like longer walltime and multi-node computation is only abvailable through the job queue.

--- a/Code_Exercises/Exercise_07_USM_Selector/README.md
+++ b/Code_Exercises/Exercise_07_USM_Selector/README.md
@@ -26,7 +26,7 @@ create a `queue` using it to select its device, remember to handle errors.
 
 #### Build And Execution Hints
 
-For For DPC++ (using the Intel DevCloud):
+For DPC++ (using the Intel DevCloud):
 ```sh
 icpx -fsycl -o sycl-ex-7 -I../External/Catch2/single_include ../Code_Exercises/Exercise_07_USM_Selector/source.cpp
 ```

--- a/Code_Exercises/Exercise_08_USM_Vector_Add/README.md
+++ b/Code_Exercises/Exercise_08_USM_Vector_Add/README.md
@@ -70,7 +70,7 @@ SYCL API `free` and not the standard C `free`.
 
 #### Build And Execution Hints
 
-For For DPC++ (using the Intel DevCloud):
+For DPC++ (using the Intel DevCloud):
 ```sh
 icpx -fsycl -o sycl-ex-8 -I../External/Catch2/single_include ../Code_Exercises/Exercise_08_USM_Vector_Add/source.cpp
 ```

--- a/Code_Exercises/Exercise_08_USM_Vector_Add/README.md
+++ b/Code_Exercises/Exercise_08_USM_Vector_Add/README.md
@@ -72,7 +72,7 @@ SYCL API `free` and not the standard C `free`.
 
 For For DPC++ (using the Intel DevCloud):
 ```sh
-clang++ -fsycl -o sycl-ex-8 -I../External/Catch2/single_include ../Code_Exercises/Exercise_08_USM_Vector_Add/source.cpp
+icpx -fsycl -o sycl-ex-8 -I../External/Catch2/single_include ../Code_Exercises/Exercise_08_USM_Vector_Add/source.cpp
 ```
 In Intel DevCloud, to run computational applications, you will submit jobs to a queue for execution on compute nodes,
 especially some features like longer walltime and multi-node computation is only abvailable through the job queue.

--- a/Code_Exercises/Exercise_09_Synchronization/README.md
+++ b/Code_Exercises/Exercise_09_Synchronization/README.md
@@ -51,7 +51,7 @@ pointer provided to the `buffer` but this is not guaranteed.
 
 For For DPC++ (using the Intel DevCloud):
 ```sh
-clang++ -fsycl -o sycl-ex-9 -I../External/Catch2/single_include ../Code_Exercises/Exercise_09_Synchronization/source.cpp
+icpx -fsycl -o sycl-ex-9 -I../External/Catch2/single_include ../Code_Exercises/Exercise_09_Synchronization/source.cpp
 ```
 In Intel DevCloud, to run computational applications, you will submit jobs to a queue for execution on compute nodes,
 especially some features like longer walltime and multi-node computation is only abvailable through the job queue.

--- a/Code_Exercises/Exercise_09_Synchronization/README.md
+++ b/Code_Exercises/Exercise_09_Synchronization/README.md
@@ -49,7 +49,7 @@ pointer provided to the `buffer` but this is not guaranteed.
 
 #### Build And Execution Hints
 
-For For DPC++ (using the Intel DevCloud):
+For DPC++ (using the Intel DevCloud):
 ```sh
 icpx -fsycl -o sycl-ex-9 -I../External/Catch2/single_include ../Code_Exercises/Exercise_09_Synchronization/source.cpp
 ```

--- a/Code_Exercises/Exercise_10_Managing_Dependencies/README.md
+++ b/Code_Exercises/Exercise_10_Managing_Dependencies/README.md
@@ -40,7 +40,7 @@ but remember to handle errors.
 
 #### Build And Execution Hints
 
-For For DPC++ (using the Intel DevCloud):
+For DPC++ (using the Intel DevCloud):
 ```sh
 icpx -fsycl -o sycl-ex-10 -I../External/Catch2/single_include ../Code_Exercises/Exercise_10_Managing_Dependencies/source.cpp
 ```

--- a/Code_Exercises/Exercise_10_Managing_Dependencies/README.md
+++ b/Code_Exercises/Exercise_10_Managing_Dependencies/README.md
@@ -42,7 +42,7 @@ but remember to handle errors.
 
 For For DPC++ (using the Intel DevCloud):
 ```sh
-clang++ -fsycl -o sycl-ex-10 -I../External/Catch2/single_include ../Code_Exercises/Exercise_10_Managing_Dependencies/source.cpp
+icpx -fsycl -o sycl-ex-10 -I../External/Catch2/single_include ../Code_Exercises/Exercise_10_Managing_Dependencies/source.cpp
 ```
 In Intel DevCloud, to run computational applications, you will submit jobs to a queue for execution on compute nodes,
 especially some features like longer walltime and multi-node computation is only abvailable through the job queue.

--- a/Code_Exercises/Exercise_15_Image_Convolution/README.md
+++ b/Code_Exercises/Exercise_15_Image_Convolution/README.md
@@ -60,5 +60,5 @@ make exercise_15_image_convolution_reference
 ```
 #### DPC++
 ```
-clang++ -fsycl -I../../External/Catch2/single_include -I../../Utilities/include/ -I../../External/stb reference.cpp
+icpx -fsycl -I../../External/Catch2/single_include -I../../Utilities/include/ -I../../External/stb reference.cpp
 ```

--- a/Code_Exercises/Exercise_16_Coalesced_Global_Memory/README.md
+++ b/Code_Exercises/Exercise_16_Coalesced_Global_Memory/README.md
@@ -32,6 +32,6 @@ make exercise_16_coalesced_global_memory_source
 ```
 #### DPC++:
 ```
-clang++ -fsycl -I../../External/Catch2/single_include -I../../Utilities/include/ -I../../External/stb solution.cpp
+icpx -fsycl -I../../External/Catch2/single_include -I../../Utilities/include/ -I../../External/stb solution.cpp
 ```
 

--- a/Code_Exercises/Exercise_17_Vectors/README.md
+++ b/Code_Exercises/Exercise_17_Vectors/README.md
@@ -36,5 +36,5 @@ make exercise_17_vectors_source
 ```
 #### DPC++
 ```
-clang++ -fsycl -I../../External/Catch2/single_include -I../../Utilities/include/ -I../../External/stb solution.cpp
+icpx -fsycl -I../../External/Catch2/single_include -I../../Utilities/include/ -I../../External/stb solution.cpp
 ```

--- a/Code_Exercises/Exercise_18_Local_Memory_Tiling/README.md
+++ b/Code_Exercises/Exercise_18_Local_Memory_Tiling/README.md
@@ -39,5 +39,5 @@ make exercise_18_local_memory_tiling_source
 ```
 #### DPC++
 ```
-clang++ -fsycl -I../../External/Catch2/single_include -I../../Utilities/include/ -I../../External/stb solution.cpp
+icpx -fsycl -I../../External/Catch2/single_include -I../../Utilities/include/ -I../../External/stb solution.cpp
 ```

--- a/Code_Exercises/Exercise_19_Work_Group_Sizes/README.md
+++ b/Code_Exercises/Exercise_19_Work_Group_Sizes/README.md
@@ -27,5 +27,5 @@ make exercise_19_work_group_sizes_source
 ```
 #### DPC++
 ```
-clang++ -fsycl -I../../External/Catch2/single_include -I../../Utilities/include/ -I../../External/stb solution.cpp
+icpx -fsycl -I../../External/Catch2/single_include -I../../Utilities/include/ -I../../External/stb solution.cpp
 ```


### PR DESCRIPTION
The main thing here is the replacement of `clang++` with `icpx` in the DPC++ build hints. This is because, as of release 2022.0.0, the standard LLVM binaries in the Intel oneAPI compiler package (in particular `clang++`) have been placed in a separate `bin-llvm` directory which is not added to the `PATH` environment variable by default (see [the relevant release notes](
https://www.intel.com/content/www/us/en/developer/articles/release-notes/intel-oneapi-dpc-c-compiler-release-notes-2022.html#inpage-nav-4)). This means the `clang++` command is not available by default on the Intel DevCloud (or at least it wasn't for me when I checked today).

Note that `icpx -fsycl` is the suggested replacement for the deprecated `dpcpp` command which was removed in #90.

I've also fixed a duplicated word typo ("For For") that seemed to be repeated throughout these READMEs.