### PR TITLE
Include SYCL header via sycl/sycl.hpp only

### DIFF
--- a/Code_Exercises/Exercise_01_Compiling_with_SYCL/solution.cpp
+++ b/Code_Exercises/Exercise_01_Compiling_with_SYCL/solution.cpp
@@ -11,11 +11,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 // The below tests that the header file has been included
 TEST_CASE("empty_sycl_source_file", "compiling_with_sycl_solution") {

--- a/Code_Exercises/Exercise_02_Hello_World/solution.cpp
+++ b/Code_Exercises/Exercise_02_Hello_World/solution.cpp
@@ -11,11 +11,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 class hello_world;
 

--- a/Code_Exercises/Exercise_02_Hello_World/source.cpp
+++ b/Code_Exercises/Exercise_02_Hello_World/source.cpp
@@ -12,11 +12,7 @@
  * ~~~~~~~~~~~~~~~~~~~~
  *
  * // Include SYCL header
- * #if __has_include(<SYCL/sycl.hpp>)
- * #include <SYCL/sycl.hpp>
- * #else
- * #include <CL/sycl.hpp>
- * #endif
+ * #include <sycl/sycl.hpp>
  *
  *
  * // Default construct a queue

--- a/Code_Exercises/Exercise_03_Scalar_Add/solution.cpp
+++ b/Code_Exercises/Exercise_03_Scalar_Add/solution.cpp
@@ -11,11 +11,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 class scalar_add_usm;
 class scalar_add_buff_acc;

--- a/Code_Exercises/Exercise_03_Scalar_Add/source.cpp
+++ b/Code_Exercises/Exercise_03_Scalar_Add/source.cpp
@@ -11,11 +11,7 @@
  * ~~~~~~~~~~~~~~~~~~~~
  *
  * // Include SYCL header
- * #if __has_include(<SYCL/sycl.hpp>)
- * #include <SYCL/sycl.hpp>
- * #else
- * #include <CL/sycl.hpp>
- * #endif
+ * #include <sycl/sycl.hpp>
  *
  * // Default construct a queue
  * auto q = sycl::queue{};

--- a/Code_Exercises/Exercise_04_Handling_Errors/solution.cpp
+++ b/Code_Exercises/Exercise_04_Handling_Errors/solution.cpp
@@ -11,11 +11,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 class scalar_add;
 

--- a/Code_Exercises/Exercise_05_Device_Selection/solution.cpp
+++ b/Code_Exercises/Exercise_05_Device_Selection/solution.cpp
@@ -11,11 +11,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 class scalar_add;
 

--- a/Code_Exercises/Exercise_06_Vector_Add/solution.cpp
+++ b/Code_Exercises/Exercise_06_Vector_Add/solution.cpp
@@ -11,11 +11,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 class vector_add;
 

--- a/Code_Exercises/Exercise_07_USM_Selector/solution.cpp
+++ b/Code_Exercises/Exercise_07_USM_Selector/solution.cpp
@@ -11,11 +11,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 class usm_selector : public sycl::device_selector {
  public:

--- a/Code_Exercises/Exercise_08_USM_Vector_Add/solution.cpp
+++ b/Code_Exercises/Exercise_08_USM_Vector_Add/solution.cpp
@@ -11,11 +11,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 class vector_add;
 

--- a/Code_Exercises/Exercise_09_Synchronization/solution.cpp
+++ b/Code_Exercises/Exercise_09_Synchronization/solution.cpp
@@ -11,11 +11,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 class vector_add_1;
 class vector_add_2;

--- a/Code_Exercises/Exercise_10_Managing_Dependencies/solution.cpp
+++ b/Code_Exercises/Exercise_10_Managing_Dependencies/solution.cpp
@@ -11,11 +11,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 class kernel_a_1;
 class kernel_b_1;

--- a/Code_Exercises/Exercise_11_In_Order_Queue/solution.cpp
+++ b/Code_Exercises/Exercise_11_In_Order_Queue/solution.cpp
@@ -13,11 +13,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 class kernel_a_1;
 class kernel_b_1;

--- a/Code_Exercises/Exercise_12_Temporary_Data/solution.cpp
+++ b/Code_Exercises/Exercise_12_Temporary_Data/solution.cpp
@@ -13,11 +13,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 class kernel_a_1;
 class kernel_b_1;

--- a/Code_Exercises/Exercise_13_Load_Balancing/solution.cpp
+++ b/Code_Exercises/Exercise_13_Load_Balancing/solution.cpp
@@ -11,11 +11,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 #include <algorithm>
 

--- a/Code_Exercises/Exercise_14_ND_Range_Kernel/solution.cpp
+++ b/Code_Exercises/Exercise_14_ND_Range_Kernel/solution.cpp
@@ -11,11 +11,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 class vector_add_1;
 class vector_add_2;

--- a/Code_Exercises/Exercise_15_Image_Convolution/reference.cpp
+++ b/Code_Exercises/Exercise_15_Image_Convolution/reference.cpp
@@ -17,11 +17,7 @@
 #include <benchmark.h>
 #include <image_conv.h>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 class image_convolution;
 

--- a/Code_Exercises/Exercise_16_Coalesced_Global_Memory/solution.cpp
+++ b/Code_Exercises/Exercise_16_Coalesced_Global_Memory/solution.cpp
@@ -14,11 +14,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 #include <benchmark.h>
 #include <image_conv.h>

--- a/Code_Exercises/Exercise_17_Vectors/solution.cpp
+++ b/Code_Exercises/Exercise_17_Vectors/solution.cpp
@@ -14,11 +14,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 #include <benchmark.h>
 #include <image_conv.h>

--- a/Code_Exercises/Exercise_18_Local_Memory_Tiling/solution.cpp
+++ b/Code_Exercises/Exercise_18_Local_Memory_Tiling/solution.cpp
@@ -14,11 +14,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 #include <benchmark.h>
 #include <image_conv.h>

--- a/Code_Exercises/Exercise_19_Work_Group_Sizes/solution.cpp
+++ b/Code_Exercises/Exercise_19_Work_Group_Sizes/solution.cpp
@@ -14,11 +14,7 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
-#if __has_include(<SYCL/sycl.hpp>)
-#include <SYCL/sycl.hpp>
-#else
-#include <CL/sycl.hpp>
-#endif
+#include <sycl/sycl.hpp>
 
 #include <benchmark.h>
 #include <image_conv.h>


### PR DESCRIPTION
This is consistent with the header location as described by the [SYCL 2020 spec](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:headers-and-namespaces).

I'm not sure which implementations used the `SYCL/sycl.hpp` header location other than OpenSYCL/hipSYCL but I guess any SYCL 2020 compliant implementation should have it at `sycl/sycl.hpp` and any SYCL 1.2.1 compliant implementation should have it at `CL/sycl.hpp`.