### PR TITLE
Exercise 10 fix

### DIFF
--- a/Code_Exercises/Exercise_10_Managing_Dependencies/solution.cpp
+++ b/Code_Exercises/Exercise_10_Managing_Dependencies/solution.cpp
@@ -133,19 +133,19 @@ TEST_CASE("usm_diamond", "usm_vector_add_solution") {
     auto e3 = usmQueue.memcpy(devicePtrInC, inC, sizeof(float) * dataSize);
 
     auto e4 = usmQueue.parallel_for<kernel_a_2>(
-        sycl::range{dataSize}, {e1, e2, e3}, [=](sycl::id<1> idx) {
+        sycl::range{dataSize}, e1, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrInA[globalId] = devicePtrInA[globalId] * 2.0f;
         });
 
     auto e5 = usmQueue.parallel_for<kernel_b_2>(
-        sycl::range{dataSize}, e4, [=](sycl::id<1> idx) {
+        sycl::range{dataSize}, {e2, e4}, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrInB[globalId] += devicePtrInA[globalId];
         });
 
     auto e6 = usmQueue.parallel_for<kernel_c_2>(
-        sycl::range{dataSize}, e4, [=](sycl::id<1> idx) {
+        sycl::range{dataSize}, {e3, e4}, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrInC[globalId] -= devicePtrInA[globalId];
         });

--- a/Code_Exercises/Exercise_10_Managing_Dependencies/solution.cpp
+++ b/Code_Exercises/Exercise_10_Managing_Dependencies/solution.cpp
@@ -62,7 +62,7 @@ TEST_CASE("buffer_accessor_diamond", "managing_dependencies_solution") {
 
     defaultQueue.submit([&](sycl::handler& cgh) {
       sycl::accessor accIn{bufInA, cgh, sycl::read_only};
-      sycl::accessor accOut{bufInB, cgh, sycl::write_only};
+      sycl::accessor accOut{bufInB, cgh, sycl::read_write};
 
       cgh.parallel_for<kernel_b_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
         accOut[idx] += accIn[idx];
@@ -71,7 +71,7 @@ TEST_CASE("buffer_accessor_diamond", "managing_dependencies_solution") {
 
     defaultQueue.submit([&](sycl::handler& cgh) {
       sycl::accessor accIn{bufInA, cgh, sycl::read_only};
-      sycl::accessor accOut{bufInC, cgh, sycl::write_only};
+      sycl::accessor accOut{bufInC, cgh, sycl::read_write};
 
       cgh.parallel_for<kernel_c_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
         accOut[idx] -= accIn[idx];


### PR DESCRIPTION
- Corrected the access modes in the buffer/accessor version from read_only to read_write, for the += and -= 
- Corrected unnecessary dependencies between kernel A and memcpy B/C in the USM version.