### PR TITLE
Small changes to exercises

### DIFF
--- a/Code_Exercises/Exercise_04_Handling_Errors/solution.cpp
+++ b/Code_Exercises/Exercise_04_Handling_Errors/solution.cpp
@@ -29,7 +29,7 @@ TEST_CASE("handling_errors", "handling_errors_source") {
       // This throws an exception: an accessor has a range which is
       // outside the bounds of its buffer.
       auto acc = buf.get_access(cgh, sycl::range{2}, sycl::read_write);
-    }).wait();
+    });
 
     defaultQueue.throw_asynchronous();
   } catch (const sycl::exception& e) {

--- a/Code_Exercises/Exercise_04_Handling_Errors/solution.cpp
+++ b/Code_Exercises/Exercise_04_Handling_Errors/solution.cpp
@@ -13,11 +13,7 @@
 
 #include <sycl/sycl.hpp>
 
-class scalar_add;
-
 TEST_CASE("handling_errors", "handling_errors_source") {
-  int a = 18, b = 24, r = 0;
-
   try {
     auto asyncHandler = [&](sycl::exception_list exceptionList) {
       for (auto& e : exceptionList) {
@@ -27,26 +23,18 @@ TEST_CASE("handling_errors", "handling_errors_source") {
 
     auto defaultQueue = sycl::queue{asyncHandler};
 
-    {
-      auto bufA = sycl::buffer{&a, sycl::range{1}};
-      auto bufB = sycl::buffer{&b, sycl::range{1}};
-      auto bufR = sycl::buffer{&r, sycl::range{1}};
+    auto buf = sycl::buffer<int>(sycl::range{1});
 
-      defaultQueue
-          .submit([&](sycl::handler& cgh) {
-            auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
-            auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
-            auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
-
-            cgh.single_task<scalar_add>([=]() { accR[0] = accA[0] + accB[0]; });
-          })
-          .wait();
-    }
+    defaultQueue.submit([&](sycl::handler& cgh) {
+      // This throws an exception: an accessor has a range which is
+      // outside the bounds of its buffer.
+      auto acc = buf.get_access(cgh, sycl::range{2}, sycl::read_write);
+    }).wait();
 
     defaultQueue.throw_asynchronous();
   } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  REQUIRE(r == 42);
+  REQUIRE(true);
 }

--- a/Code_Exercises/Exercise_04_Handling_Errors/solution.cpp
+++ b/Code_Exercises/Exercise_04_Handling_Errors/solution.cpp
@@ -30,11 +30,10 @@ TEST_CASE("handling_errors", "handling_errors_source") {
       // outside the bounds of its buffer.
       auto acc = buf.get_access(cgh, sycl::range{2}, sycl::read_write);
     });
-    printf("This should print before an exception is thrown!\n");
     defaultQueue.wait_and_throw();
   } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
-
+  
   REQUIRE(true);
 }

--- a/Code_Exercises/Exercise_04_Handling_Errors/solution.cpp
+++ b/Code_Exercises/Exercise_04_Handling_Errors/solution.cpp
@@ -30,7 +30,7 @@ TEST_CASE("handling_errors", "handling_errors_source") {
       // outside the bounds of its buffer.
       auto acc = buf.get_access(cgh, sycl::range{2}, sycl::read_write);
     });
-
+printf("This should print before an exception is thrown!\n");
     defaultQueue.wait_and_throw();
   } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;

--- a/Code_Exercises/Exercise_04_Handling_Errors/solution.cpp
+++ b/Code_Exercises/Exercise_04_Handling_Errors/solution.cpp
@@ -30,7 +30,7 @@ TEST_CASE("handling_errors", "handling_errors_source") {
       // outside the bounds of its buffer.
       auto acc = buf.get_access(cgh, sycl::range{2}, sycl::read_write);
     });
-printf("This should print before an exception is thrown!\n");
+    printf("This should print before an exception is thrown!\n");
     defaultQueue.wait_and_throw();
   } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;

--- a/Code_Exercises/Exercise_04_Handling_Errors/solution.cpp
+++ b/Code_Exercises/Exercise_04_Handling_Errors/solution.cpp
@@ -31,7 +31,7 @@ TEST_CASE("handling_errors", "handling_errors_source") {
       auto acc = buf.get_access(cgh, sycl::range{2}, sycl::read_write);
     });
 
-    defaultQueue.throw_asynchronous();
+    defaultQueue.wait_and_throw();
   } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }

--- a/Code_Exercises/Exercise_08_USM_Vector_Add/README.md
+++ b/Code_Exercises/Exercise_08_USM_Vector_Add/README.md
@@ -42,7 +42,7 @@ Now you can define the kernel function itself, which is largely the same as in
 exercise 7.
 
 This can be done differently from the buffer/accessor model, by calling the
-shortcut member function `single_task` on the `queue` rather than creating a
+shortcut member function `parallel_for` on the `queue` rather than creating a
 command group.
 
 Note that as you are accessing a pointer rather than an `accessor` you must

--- a/Code_Exercises/Exercise_16_Coalesced_Global_Memory/README.md
+++ b/Code_Exercises/Exercise_16_Coalesced_Global_Memory/README.md
@@ -11,7 +11,7 @@ coalesced global memory access.
 
 ### 1.) Evaluate global memory access
 
-Now that you have a working grayscaling kernel you should evaluate whether the
+Now that you have a working image convolution kernel you should evaluate whether the
 global memory access patterns in your kernel are coalesced.
 
 Consider two alternative ways to linearize the global id:

--- a/Code_Exercises/Exercise_18_Local_Memory_Tiling/solution.cpp
+++ b/Code_Exercises/Exercise_18_Local_Memory_Tiling/solution.cpp
@@ -95,7 +95,7 @@ TEST_CASE("image_convolution_tiled", "local_memory_tiling_solution") {
 
                     // Explanation:
                     // We need to read pixels from the neighbouring work-groups 
-                    // too, so we have more pixels to read than items in a work-
+                    // too, so we have more pixels to read than items per work-
                     // group. We solve this by having each work item also read 
                     // the pixel at their local index in the neighbouring group 
                     // if that pixel is part of the halo.

--- a/Code_Exercises/Exercise_18_Local_Memory_Tiling/solution.cpp
+++ b/Code_Exercises/Exercise_18_Local_Memory_Tiling/solution.cpp
@@ -93,6 +93,12 @@ TEST_CASE("image_convolution_tiled", "local_memory_tiling_solution") {
                     auto localId = item.get_local_id();
                     auto globalGroupOffset = groupId * localRange;
 
+                    // Explanation:
+                    // We need to read pixels from the neighbouring work-groups 
+                    // too, so we have more pixels to read than items in a work-
+                    // group. We solve this by having each work item also read 
+                    // the pixel at their local index in the neighbouring group 
+                    // if that pixel is part of the halo.
                     for (auto i = localId[0]; i < scratchpadRange[0];
                          i += localRange[0]) {
                       for (auto j = localId[1]; j < scratchpadRange[1];

--- a/Lesson_Materials/Lecture_04_Handling_Errors/index.html
+++ b/Lesson_Materials/Lecture_04_Handling_Errors/index.html
@@ -76,6 +76,35 @@
 						  * Asynchronous errors (thrown by the SYCL scheduler).
 					</div>
 				</section>
+				<section>
+					<div class="hbox" data-markdown>
+						#### Handling errors
+					</div>
+					<div class="hbox" >
+						<code class="code-60pc"><pre>
+int main() {
+  queue q();
+
+  /* Synchronous code */
+
+  q.submit([&](handler &cgh) {
+
+    /* Synchronous code */
+
+    cgh.single_task&lt;add&gt;(bufO.get_range(), [=](id&lt;1&gt; i) {
+
+      /* Asynchronous code */
+
+    });
+  });
+}
+						</code></pre>
+					</div>
+					<div class="bottom-bullets" data-markdown>
+					* Kernels run asynchronously on the device, and will throw asynchronous errors.
+					* Everything else runs synchronously on the host, and will throw synchronous errors.
+					</div>
+				</section>
 				<!--Slide 4-->
 				<section>
 					<div class="hbox" data-markdown>

--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ Where `<dpc++_install_root>` is wherever the `oneAPI` directory is installed.
 
 Once that's done you can invoke the DPC++ compiler as follows:
 
-`dpcpp -I<syclacademy_root>/External/Catch2/single_include -o a.out source.cpp`
+`icpx -fsycl -I<syclacademy_root>/External/Catch2/single_include -o a.out source.cpp`
 
 Where `<syclacademy_root>` is the path to the root directory of where you cloned
 this repository. Note that on Windows you need to add the option /EHsc to avoid exception handling error. 


### PR DESCRIPTION
- Changed the compiling command in README to `icpx -fsycl` from `dpcpp`.
- Changed exercise 4 to throw an exception, to help see the error handling in practice.
- Changed exercise 16's readme, which referred to the exercise as greyscaling instead of image convolution.
- Added a short explanation for exercise 18's local memory reading.
- Changed exercise 8's readme to refer to `parallel_for` instead of `single_task`.