### PR TITLE
Describe kernel naming conventions

### DIFF
--- a/Code_Exercises/Exercise_02_Hello_World/README.md
+++ b/Code_Exercises/Exercise_02_Hello_World/README.md
@@ -32,7 +32,11 @@ Within the command group function define a SYCL kernel function via the
 `single_task` command within the command group, which takes only a function
 object which itself doesn't take any parameters.
 
-Remember to declare a class for your kernel name in the global namespace.
+Remember to declare a class for your kernel name in the global namespace. While
+it is possible to leave the class declaration inline in the handler scope, this
+can produce long kernel names that show up in profiler and debugger output and
+make it harder to use. Defining the kernel names out of local scope avoids
+this.
 
 Also remember to call `wait` on the `event` returned from `submit` to await the
 completion of the kernel function.


### PR DESCRIPTION
Kernel names are better placed close to the top scope level, as it avoids the problems of the name being excessively long (which shows up in the debugger, for example, and hurts readability).

Closes #268 