### PR TITLE
Fix non-deterministic fail in Exercise 03

### DIFF
--- a/Code_Exercises/Exercise_03_Scalar_Add/solution.cpp
+++ b/Code_Exercises/Exercise_03_Scalar_Add/solution.cpp
@@ -25,13 +25,13 @@ TEST_CASE("scalar_add_usm", "scalar_add_solution") {
   auto dev_B = sycl::malloc_device<int>(1, defaultQueue);
   auto dev_R = sycl::malloc_device<int>(1, defaultQueue);
 
-  defaultQueue.memcpy(dev_A, &a, 1 * sizeof(int));
-  defaultQueue.memcpy(dev_B, &b, 1 * sizeof(int));
+  defaultQueue.memcpy(dev_A, &a, 1 * sizeof(int)).wait();
+  defaultQueue.memcpy(dev_B, &b, 1 * sizeof(int)).wait();
 
   defaultQueue
       .submit([&](sycl::handler &cgh) {
         cgh.single_task<scalar_add_usm>([=] { dev_R[0] = dev_A[0] + dev_B[0]; });
-      });
+      }).wait();
 
   defaultQueue.memcpy(&r, dev_R, 1 * sizeof(int)).wait();
 


### PR DESCRIPTION
Without the waits the included `solution.cpp` sometimes fails.

Another way would be to make the queue in_order, but that is only introduced later in Exercise 11.

I'm using the latest https://github.com/OpenSYCL/OpenSYCL + ROCm 5.4.4

-------------------------------

Thanks for this nice SYCL intro!