### PR TITLE
Update AdaptiveCpp documentation/cmake integration/Intel GPU support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,8 +75,8 @@ if (SYCL_ACADEMY_USE_ADAPTIVECPP)
     "the path to the root of the chosen SYCL implementation using "
     "SYCL_ACADEMY_INSTALL_ROOT=<path/to/install/root>.")
   endif()
-  set(hipSYCL_DIR ${SYCL_ACADEMY_INSTALL_ROOT}/lib/cmake/hipSYCL)
-  find_package(hipSYCL CONFIG REQUIRED PATHS)
+  set(AdaptiveCpp_DIR ${SYCL_ACADEMY_INSTALL_ROOT}/lib/cmake/AdaptiveCpp)
+  find_package(AdaptiveCpp CONFIG REQUIRED PATHS)
 endif()
 
 # Exercises

--- a/Code_Exercises/CMakeLists.txt
+++ b/Code_Exercises/CMakeLists.txt
@@ -11,8 +11,10 @@
 # CMake function to build ab AdaptiveCpp configuration and create executable binaries
 # from AdaptiveCpp libraries. 
 function( add_sycl_executable_adaptivecpp prefix source )
-  add_executable("${prefix}_${source}" "${source}.cpp")
-  target_compile_definitions("${prefix}_${source}" PUBLIC -DSYCL_LANGUAGE_VERSION=2020)
+  set(TARGET_NAME "${prefix}_${source}")
+  add_executable("${TARGET_NAME}" "${source}.cpp")
+  add_sycl_to_target(TARGET ${TARGET_NAME} SOURCES "${source}.cpp") 
+  
   target_include_directories("${prefix}_${source}" PRIVATE
     ${PROJECT_SOURCE_DIR}/Utilities/include 
     ${PROJECT_SOURCE_DIR}/External/stb)

--- a/Code_Exercises/Exercise_01_Compiling_with_SYCL/README.md
+++ b/Code_Exercises/Exercise_01_Compiling_with_SYCL/README.md
@@ -19,14 +19,21 @@ Depending on the SYCL implementation used, the steps to verify your environment 
 
 #### When using AdaptiveCpp
 
-With AdaptiveCpp, you can skip this step. If you suspect later that your environment might not be set up correctly, you can set the environment variable `ACPP_DEBUG_LEVEL=3` and execute your program. AdaptiveCpp will then print (among many other things) all devices that it can find, for example:
-```sh
-[AdaptiveCpp Info] Discovered devices from backend 'OpenMP': 
-[AdaptiveCpp Info]   device 0: 
-[AdaptiveCpp Info]     vendor: the AdaptiveCpp project
-[AdaptiveCpp Info]     name: AdaptiveCpp OpenMP host device
+With AdaptiveCpp, you can skip this step. If you suspect later that your environment might not be set up correctly, you can run `acpp-info -l` in the `bin`  directory of your AdaptiveCpp installation. It will then print the backends and devices that it sees, for example:
 ```
-*Note: You may not see this output in this exercise because we do not yet actually use any SYCL functionality. Consequently, there is no need for the AdaptiveCpp runtime to launch and print diagnostic information.*
+$ acpp-info -l
+=================Backend information===================
+Loaded backend 0: OpenCL
+  Found device: Intel(R) UHD Graphics 620 [0x5917]
+  Found device: ComputeAorta x86_64
+  Found device: Intel(R) Core(TM) i7-8550U CPU @ 1.80GHz
+Loaded backend 1: OpenMP
+  Found device: hipSYCL OpenMP host device
+Loaded backend 2: CUDA
+  Found device: NVIDIA GeForce MX150
+Loaded backend 3: Level Zero
+  Found device: Intel(R) UHD Graphics 620 [0x5917]
+```
 
 ### 3.) Configuring the exercise project
 
@@ -94,7 +101,7 @@ make exercise_1
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_01_compiling_with_SYCL
-/path/to/AdaptiveCpp/bin/acpp -o sycl-ex-1 -I../../External/Catch2/single_include --hipsycl-targets="<target specification>" source.cpp
+/path/to/AdaptiveCpp/bin/acpp -o sycl-ex-1 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-1
 ```
 

--- a/Code_Exercises/Exercise_01_Compiling_with_SYCL/README.md
+++ b/Code_Exercises/Exercise_01_Compiling_with_SYCL/README.md
@@ -19,7 +19,7 @@ Depending on the SYCL implementation used, the steps to verify your environment 
 
 #### When using AdaptiveCpp
 
-With AdaptiveCpp, you can skip this step. If you suspect later that your environment might not be set up correctly, you can set the environment variable `ADAPTIVECPP_DEBUG_LEVEL=3` and execute your program. hipSYCL will then print (among many other things) all devices that it can find, for example:
+With AdaptiveCpp, you can skip this step. If you suspect later that your environment might not be set up correctly, you can set the environment variable `ACPP_DEBUG_LEVEL=3` and execute your program. AdaptiveCpp will then print (among many other things) all devices that it can find, for example:
 ```sh
 [AdaptiveCpp Info] Discovered devices from backend 'OpenMP': 
 [AdaptiveCpp Info]   device 0: 
@@ -86,15 +86,15 @@ qsub job_submission
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/AdaptiveCpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/AdaptiveCpp -DACPP_TARGETS="<target specification>" ..
 make exercise_1
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_01_compiling_with_SYCL
-/path/to/AdaptiveCpp/bin/syclcc -o sycl-ex-1 -I../../External/Catch2/single_include --hipsycl-targets="<target specification>" source.cpp
+/path/to/AdaptiveCpp/bin/acpp -o sycl-ex-1 -I../../External/Catch2/single_include --hipsycl-targets="<target specification>" source.cpp
 ./sycl-ex-1
 ```
 

--- a/Code_Exercises/Exercise_02_Hello_World/README.md
+++ b/Code_Exercises/Exercise_02_Hello_World/README.md
@@ -78,16 +78,16 @@ qsub job_submission
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
 cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_ENABLE_SOLUTIONS=OFF
--DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+-DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_2
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_02_Hello_World
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-2 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-2 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-2
 ```
 

--- a/Code_Exercises/Exercise_03_Scalar_Add/README.md
+++ b/Code_Exercises/Exercise_03_Scalar_Add/README.md
@@ -71,15 +71,15 @@ qsub job_submission
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adapivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adapivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_3
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_03_Scalar_Add
-/path/to/AdaptiveCpp/bin/syclcc -o sycl-ex-3 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/AdaptiveCpp/bin/acpp -o sycl-ex-3 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-3
 ```
 

--- a/Code_Exercises/Exercise_04_Handling_Errors/README.md
+++ b/Code_Exercises/Exercise_04_Handling_Errors/README.md
@@ -55,15 +55,15 @@ qsub job_submission
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/AdaptiveCpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/AdaptiveCpp -DACPP_TARGETS="<target specification>" ..
 make exercise_4
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_04_Handling_Errors
-/path/to/AdaptiveCpp/bin/syclcc -o sycl-ex-4 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/AdaptiveCpp/bin/acpp -o sycl-ex-4 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-4
 ```
 

--- a/Code_Exercises/Exercise_04_Handling_Errors/source.cpp
+++ b/Code_Exercises/Exercise_04_Handling_Errors/source.cpp
@@ -11,6 +11,8 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
+#include <sycl/sycl.hpp>
+
 TEST_CASE("handling_errors", "handling_errors_source") {
 
   // Task: catch synchronous and asynchronous exceptions

--- a/Code_Exercises/Exercise_05_Device_Selection/README.md
+++ b/Code_Exercises/Exercise_05_Device_Selection/README.md
@@ -77,15 +77,15 @@ qsub job_submission
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_5
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_05_Device_Selection
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-5 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-5 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-5
 ```
 

--- a/Code_Exercises/Exercise_05_Device_Selection/source.cpp
+++ b/Code_Exercises/Exercise_05_Device_Selection/source.cpp
@@ -48,8 +48,13 @@
  *
 */
 
+
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
+
+#include <sycl/sycl.hpp>
+
+class scalar_add;
 
 TEST_CASE("intel_gpu_device_selector", "device_selectors_solution") {
   int a = 18, b = 24, r = 0;

--- a/Code_Exercises/Exercise_06_Vector_Add/README.md
+++ b/Code_Exercises/Exercise_06_Vector_Add/README.md
@@ -62,15 +62,15 @@ qsub job_submission
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_6
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_06_Vector_Add
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-6 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-6 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-6
 ```
 

--- a/Code_Exercises/Exercise_07_USM_Selector/README.md
+++ b/Code_Exercises/Exercise_07_USM_Selector/README.md
@@ -51,15 +51,15 @@ qsub job_submission
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_7 
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_07_USM_Selector
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-7 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-7 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-7
 ```
 

--- a/Code_Exercises/Exercise_07_USM_Selector/source.cpp
+++ b/Code_Exercises/Exercise_07_USM_Selector/source.cpp
@@ -11,6 +11,8 @@
 #define CATCH_CONFIG_MAIN
 #include <catch2/catch.hpp>
 
+#include <sycl/sycl.hpp>
+
 TEST_CASE("usm_selector", "usm_selector_source") {
 
   // Task: create a queue to a device which supports USM allocations

--- a/Code_Exercises/Exercise_08_USM_Vector_Add/README.md
+++ b/Code_Exercises/Exercise_08_USM_Vector_Add/README.md
@@ -93,15 +93,15 @@ qsub job_submission
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_8
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_08_USM_Vector_Add
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-8 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-8 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-8
 ```
 

--- a/Code_Exercises/Exercise_09_Synchronization/README.md
+++ b/Code_Exercises/Exercise_09_Synchronization/README.md
@@ -74,15 +74,15 @@ qsub job_submission
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_9
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_09_Synchronization
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-9 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-9 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-9
 ```
 

--- a/Code_Exercises/Exercise_10_Managing_Dependencies/README.md
+++ b/Code_Exercises/Exercise_10_Managing_Dependencies/README.md
@@ -65,15 +65,15 @@ qsub job_submission
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_10 
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_10_Managing_Dependencies
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-10 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-10 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-10
 ```
 

--- a/Code_Exercises/Exercise_11_In_Order_Queue/README.md
+++ b/Code_Exercises/Exercise_11_In_Order_Queue/README.md
@@ -48,14 +48,14 @@ icpx -fsycl -o sycl-ex-11 -I../External/Catch2/single_include ../Code_Exercises/
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_11
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_11_In_Order_Queue
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-11 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-11 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-11
 ```

--- a/Code_Exercises/Exercise_12_Temporary_Data/README.md
+++ b/Code_Exercises/Exercise_12_Temporary_Data/README.md
@@ -55,14 +55,14 @@ icpx -fsycl -o sycl-ex-12 -I../External/Catch2/single_include ../Code_Exercises/
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_12
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_12_Temporary_Data
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-12 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-12 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-12
 ```

--- a/Code_Exercises/Exercise_13_Load_Balancing/README.md
+++ b/Code_Exercises/Exercise_13_Load_Balancing/README.md
@@ -56,14 +56,14 @@ icpx -fsycl -o sycl-ex-13 -I../External/Catch2/single_include ../Code_Exercises/
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_13
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_13_Load_Balancing
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-13 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-13 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-13
 ```

--- a/Code_Exercises/Exercise_14_ND_Range_Kernel/README.md
+++ b/Code_Exercises/Exercise_14_ND_Range_Kernel/README.md
@@ -58,14 +58,14 @@ icpx -fsycl -o sycl-ex-14 -I../External/Catch2/single_include ../Code_Exercises/
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_14
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_14_ND_Range_Kernel
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-14 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-14 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-14
 ```

--- a/Code_Exercises/Exercise_15_Image_Convolution/README.md
+++ b/Code_Exercises/Exercise_15_Image_Convolution/README.md
@@ -69,13 +69,13 @@ icpx -fsycl -o sycl-ex-15 -I../../Utilities/include/ -I../../External/stb refere
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_15
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_15_Image_Convolution
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-15 -I../../Utilities/include/ -I../../External/stb --adaptivecpp-targets="<target specification>" reference.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-15 -I../../Utilities/include/ -I../../External/stb --acpp-targets="<target specification>" reference.cpp
 ```

--- a/Code_Exercises/Exercise_16_Coalesced_Global_Memory/README.md
+++ b/Code_Exercises/Exercise_16_Coalesced_Global_Memory/README.md
@@ -42,14 +42,14 @@ icpx -fsycl -o sycl-ex-16 -I../External/Catch2/single_include ../Code_Exercises/
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_16
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_16_Coalesced_Global_Memory
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-16 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-16 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-16
 ```

--- a/Code_Exercises/Exercise_17_Vectors/README.md
+++ b/Code_Exercises/Exercise_17_Vectors/README.md
@@ -46,14 +46,14 @@ icpx -fsycl -o sycl-ex-17 -I../External/Catch2/single_include ../Code_Exercises/
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_17
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_17_Vectors
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-17 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-17 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-17
 ```

--- a/Code_Exercises/Exercise_18_Local_Memory_Tiling/README.md
+++ b/Code_Exercises/Exercise_18_Local_Memory_Tiling/README.md
@@ -47,14 +47,14 @@ icpx -fsycl -o sycl-ex-18 -I../External/Catch2/single_include ../Code_Exercises/
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/adaptivecpp -DACPP_TARGETS="<target specification>" ..
 make exercise_14
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_18_Local_Memory_Tiling
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-18 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-18 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-18
 ```

--- a/Code_Exercises/Exercise_19_Work_Group_Sizes/README.md
+++ b/Code_Exercises/Exercise_19_Work_Group_Sizes/README.md
@@ -37,14 +37,14 @@ icpx -fsycl -o sycl-ex-19 -I../External/Catch2/single_include ../Code_Exercises/
 For AdaptiveCpp:
 ```sh
 # <target specification> is a list of backends and devices to target, for example
-# "omp;hip:gfx900,gfx906" compiles for CPUs with the OpenMP backend and for AMD Vega 10 (gfx900) and Vega 20 (gfx906) GPUs using the HIP backend.
+# "omp;generic" compiles for CPUs with the OpenMP backend and GPUs using the generic single-pass compiler.
 # The simplest target specification is "omp" which compiles for CPUs using the OpenMP backend.
-cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/AdaptiveCpp -DADAPTIVECPP_TARGETS="<target specification>" ..
+cmake -DSYCL_ACADEMY_USE_ADAPTIVECPP=ON -DSYCL_ACADEMY_INSTALL_ROOT=/insert/path/to/AdaptiveCpp -DACPP_TARGETS="<target specification>" ..
 make exercise_19
 ```
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Exercise_19_Work_Group_Sizes
-/path/to/adaptivecpp/bin/syclcc -o sycl-ex-19 -I../../External/Catch2/single_include --adaptivecpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-ex-19 -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
 ./sycl-ex-19
 ```

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ all of the exercises.
 | Implementation | Supported Platforms | Supported Devices | Required Version |
 |----------------|---------------------|-------------------|------------------|
 | DPC++ | [Intel DevCloud](https://tinyurl.com/getdevcloud) <br> Windows 10 Visual Studio 2019 (64bit) <br> Red Hat Enterprise Linux 8, CentOS 8<br> Ubtuntu 18.04 LTS, 20.04 LTS (64bit)<br> Refer to [System Requirements][oneAPI-system-requirements] for more details | Intel CPU (OpenCL) <br> Intel GPU (OpenCL) <br> Intel FPGA (OpenCL) <br> Nvidia GPU (CUDA)* | 2021.4	|
-| AdaptiveCpp | Any Linux | CPU (OpenMP) <br> AMD GPU (ROCm)*** <br> NVIDIA GPU (CUDA) | Latest develop branch |
+| AdaptiveCpp | Any Linux | CPU (OpenMP) <br> AMD GPU (ROCm)*** <br> NVIDIA GPU (CUDA)<br> Intel GPU (Level Zero)<br> Intel CPU, GPU (OpenCL) | 23.10.0 from Nov 1, 2023 or newer |
 
 \* Supported in open source project only
 
@@ -194,15 +194,17 @@ This SYCL Academy CMake configuration uses the Intel oneAPI IntelSYCL CMake modu
 #### Additional cmake arguments for AdaptiveCpp
 
 When building with AdaptiveCpp, cmake will additionally require you to specify the
-target platform using `-DHIPSYCL_TARGETS=<target specification>`. 
-`<target specification>` is a list of backends and devices to target, for example
-`-DHIPSYCL_TARGETS="omp;hip:gfx900,gfx906"` compiles for CPUs with the OpenMP backend
-and for AMD Vega 10 and Vega 20 GPUs using the HIP backend.
-Available backends are:
+target platform using `-DACPP_TARGETS=<target specification>`. 
+`<target specification>` is a list of compilation flows to enable and devices to target, for example
+`-DACPP_TARGETS="omp;generic"` compiles for CPUs using OpenMP and GPUs using the generic single-pass compiler.
+
+Available compilation flows are:
 * `omp` - OpenMP CPU backend
+* `generic` - Generic single-pass compiler. Generates a binary that runs on AMD, NVIDIA and Intel GPUs using runtime compilation
 * `cuda` - CUDA backend for NVIDIA GPUs. Requires specification of targets of the form sm_XY, e.g. sm_70 for Volta, sm_60 for Pascal
 * `hip`  - HIP backend for AMD GPUs. Requires specification of targets of the form gfxXYZ, e.g. gfx906 for Vega 20, gfx900 for Vega 10
-* `spirv` - use clang SYCL driver to generate spirv (experimental)
+
+When in doubt, use `-DACPP_TARGETS=omp;generic`.
 
 #### CMake usage example
 


### PR DESCRIPTION
This PR addresses several issues with AdaptiveCpp:

* cmake integration was broken; partially because the renaming to AdaptiveCpp was not done correctly and the wrong flags were used. This PR fixes this. I believe that potentially the cmake integration between DPC++ and AdaptiveCpp could be unified, as it seems that DPC++ now also has `add_sycl_to_target()` (?)
* Fixes some minor issues in skeleton source files for the exercises that prevented a simple `cmake ... ; make` from succeeding (mostly missing `#include <sycl/sycl.hpp>`) with an unmodified clone of the repository.
* Update documentation to advertise the correct flags following the renaming
* Update documentation to advertise AdaptiveCpp Intel GPU support through the generic single-pass compiler. I've tested all exercises with the single-pass compiler on Intel hardware: Works. Which also means that it might be worth trying to get things to run on DevCloud :)
* Update documentation to refer to `acpp` instead of `syclcc`.

I can run all exercises, the only minor issue is in exercise 4 (error handling). It seems that we don't validate accessors as well as we should, so the accessor construction does not trigger an exception. Instead, it errors because the solution constructs a command group without command (the command group function only constructs an accessor).

These changes probably should also be ported to the `sc23` branch, but I'm not sure what the current process is there.