### PR TITLE
nd_range kernel: Example code must use nd_item/nd_range for get_linear_id()

### DIFF
--- a/Lesson_Materials/ND_Range_Kernel/index.html
+++ b/Lesson_Materials/ND_Range_Kernel/index.html
@@ -379,7 +379,7 @@ gpuQueue.submit([&](handler &cgh){
   sycl::accessor inA{bufA, cgh, sycl::read_only};
   sycl::accessor inB{bufB, cgh, sycl::read_only};
   sycl::accessor out{bufO, cgh, sycl::write_only};
-  cgh.parallel_for&ltadd&gt(rng, [=](id&lt3&gt i){
+  cgh.parallel_for&ltadd&gt(nd_rng, [=](nd_item&lt3&gt i){
     <mark>auto ptrA = inA.get_pointer();</mark>
     <mark>auto ptrB = inB.get_pointer();</mark>
     <mark>auto ptrO = out.get_pointer();</mark>

--- a/Lesson_Materials/ND_Range_Kernel/index.html
+++ b/Lesson_Materials/ND_Range_Kernel/index.html
@@ -379,7 +379,7 @@ gpuQueue.submit([&](handler &cgh){
   sycl::accessor inA{bufA, cgh, sycl::read_only};
   sycl::accessor inB{bufB, cgh, sycl::read_only};
   sycl::accessor out{bufO, cgh, sycl::write_only};
-  cgh.parallel_for&ltadd&gt(nd_rng, [=](nd_item&lt3&gt i){
+  cgh.parallel_for&ltadd&gt(rng, [=](item&lt3&gt i){
     <mark>auto ptrA = inA.get_pointer();</mark>
     <mark>auto ptrB = inB.get_pointer();</mark>
     <mark>auto ptrO = out.get_pointer();</mark>


### PR DESCRIPTION
We had an example that was trying to show `get_linear_id()` and `get_pointer()`. However, `get_linear_id()` is only available with `item`. This PR changes that.