### PR TITLE
Changed devcloud ssh instructions to jupiterlab

### DIFF
--- a/Code_Exercises/Advanced_Data_Flow/README.md
+++ b/Code_Exercises/Advanced_Data_Flow/README.md
@@ -38,7 +38,7 @@ unnecessary copies you can simply not perform those copies.
 
 ## Build and execution hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/Asynchronous_Execution/README.md
+++ b/Code_Exercises/Asynchronous_Execution/README.md
@@ -49,7 +49,7 @@ pointer provided to the `buffer` but this is not guaranteed.
 
 #### Build And Execution Hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/Data_Parallelism/README.md
+++ b/Code_Exercises/Data_Parallelism/README.md
@@ -37,7 +37,7 @@ the corresponding element of data that the accessor represents.
 
 #### Build And Execution Hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/Data_and_Dependencies/README.md
+++ b/Code_Exercises/Data_and_Dependencies/README.md
@@ -40,7 +40,7 @@ but remember to handle errors.
 
 #### Build And Execution Hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/Device_Discovery/README.md
+++ b/Code_Exercises/Device_Discovery/README.md
@@ -52,7 +52,7 @@ score will never be chosen.
 
 #### Build And Execution Hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/Enqueueing_a_Kernel/README.md
+++ b/Code_Exercises/Enqueueing_a_Kernel/README.md
@@ -52,7 +52,7 @@ Then use the stream you constructed within the SYCL kernel function to print
 
 #### Build And Execution Hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/Functors/README.md
+++ b/Code_Exercises/Functors/README.md
@@ -33,7 +33,7 @@ the final image.
 
 ## Build and execution hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/Handling_Errors/README.md
+++ b/Code_Exercises/Handling_Errors/README.md
@@ -29,7 +29,7 @@ exceptions to be caught by the surrounding try-catch block.
 
 #### Build And Execution Hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/In_Order_Queue/README.md
+++ b/Code_Exercises/In_Order_Queue/README.md
@@ -41,7 +41,7 @@ necessary to chain commands using `event`s.
 
 ## Build and execution hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/Introduction_to_USM/README.md
+++ b/Code_Exercises/Introduction_to_USM/README.md
@@ -26,7 +26,7 @@ create a `queue` using it to select its device, remember to handle errors.
 
 #### Build And Execution Hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/Local_Memory_Tiling/README.md
+++ b/Code_Exercises/Local_Memory_Tiling/README.md
@@ -30,7 +30,7 @@ Compare the performance with local memory and without local memory.
 
 ## Build and execution hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/Managing_Data/README.md
+++ b/Code_Exercises/Managing_Data/README.md
@@ -46,7 +46,7 @@ initializing it with just a `range` and no host pointer.
 
 #### Build And Execution Hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/Multiple_Devices/README.md
+++ b/Code_Exercises/Multiple_Devices/README.md
@@ -39,7 +39,7 @@ changing the `range` and `offset` of the two `buffer`s.
 
 ## Build and execution hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/ND_Range_Kernel/README.md
+++ b/Code_Exercises/ND_Range_Kernel/README.md
@@ -41,7 +41,7 @@ method of synchronization and copy back.
 
 ## Build and execution hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/OneMKL_gemm/README.md
+++ b/Code_Exercises/OneMKL_gemm/README.md
@@ -20,7 +20,7 @@ The source code invloves matrix array initialization on host and generate refere
 To run the example: ./OneMKL_usm_gemm_solution (or) ./OneMKL_usm_gemm_source
 To verify with CUBLAS debug info, `export CUBLAS_LOGINFO_DB=1` and `export CUBLAS_LOGDEST_DBG=stdout`
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/Using_USM/README.md
+++ b/Code_Exercises/Using_USM/README.md
@@ -68,7 +68,7 @@ SYCL API `free` and not the standard C `free`.
 
 #### Build And Execution Hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/Vectors/README.md
+++ b/Code_Exercises/Vectors/README.md
@@ -29,7 +29,7 @@ offsets to account for the number of channels.
 
 ## Build and execution hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/Work_Group_Sizes/README.md
+++ b/Code_Exercises/Work_Group_Sizes/README.md
@@ -20,7 +20,7 @@ Compare the performance of the various work-group sizes you try.
 
 ## Build and execution hints
 
-For DevCloud via SSH follow these [instructions](../devcloud.md).
+For DevCloud via JupiterLab follow these [instructions](../devcloudJupyter.md).
 
 For DPC++: [instructions](../dpcpp.md).
 

--- a/Code_Exercises/devcloudJupyter.md
+++ b/Code_Exercises/devcloudJupyter.md
@@ -18,8 +18,20 @@ Alternatively from a terminal at the command line:
 icpx -fsycl -o <exercise name>_source -I../../External/Catch2/single_include ../Code_Exercises/<Exercise directory>/source.cpp
 ```
 
-To execute just run:
+In Intel DevCloud, to run computational applications, you will submit jobs to a queue for execution on compute nodes,
+especially some features like longer walltime and multi-node computation is only available through the job queue.
+Please refer to the [guide][devcloud-job-submission].
 
+So wrap the binary into a script `job_submission`
 ```sh
+#!/bin/bash
 ./<exercise name>_source
 ```
+and run:
+```sh
+qsub -l nodes=1:gpu:ppn=2 -d . job_submission
+```
+
+The stdout will be stored in ```job_submission.o<job id>``` and stderr in ```job_submission.e<job id>```.
+
+[devcloud-job-submission]: https://devcloud.intel.com/oneapi/documentation/job-submission/


### PR DESCRIPTION
Modified most of the exercises READMEs by changing information on using SSH to access DevCloud in order to access it through JupyterLab