### PR TITLE
Sc24 Updates

### DIFF
--- a/Code_Exercises/CMakeLists.txt
+++ b/Code_Exercises/CMakeLists.txt
@@ -50,5 +50,4 @@ endfunction()
 
 add_subdirectory(Introduction_to_SYCL)
 add_subdirectory(ND_Range_Kernel)
-add_subdirectory(OneMKL_gemm)
 add_subdirectory(Image_Convolution_Functors)

--- a/Code_Exercises/ND_Range_Kernel/README.md
+++ b/Code_Exercises/ND_Range_Kernel/README.md
@@ -13,12 +13,8 @@ Using the application from any exercise so far or creating a new one, enqueue a
 kernel function using the `parallel_for` variant which takes a `range` but has
 the kernel function take an `item`.
 
-Feel free to use either the buffer/accessor model and feel free to use any
-method of synchronization and copy back.
-
-When using an `item` you cannot pass this directly to the subscript operator of
-an `accessor` you have to retrieve the `id`, you can do this by calling the
-`get_id` member function.
+Feel free to try out different USM pointers and to use any method of
+synchronization and copy back.
 
 ### 2.) Enqueue an ND range kernel
 
@@ -36,8 +32,8 @@ Similarly to to the `item` when using the `nd_item` you cannot pass this
 directly to the subscript operator of an `accessor`, you can retrieve the `id`
 by calling the `get_global_id` member function.
 
-Feel free to use either the buffer/accessor model and feel free to use any
-method of synchronization and copy back.
+Feel free to try out different USM pointers and to use any method of
+synchronization and copy back.
 
 ## Build and execution hints
 

--- a/Code_Exercises/ND_Range_Kernel/source.cpp
+++ b/Code_Exercises/ND_Range_Kernel/source.cpp
@@ -17,8 +17,8 @@
  * auto q = sycl::queue{sycl::default_selector_v,
  *        {sycl::property::queue::in_order{}}};
  *
- * // Declare a buffer pointing to ptr
- * auto buf = sycl::buffer{ptr, sycl::range{n}};
+ * // Declare a USM device pointer
+ * auto ptr = sycl::malloc_device<T>(size, queue);
  *
  * // Do a USM memcpy
  * auto event = q.memcpy(dst_ptr, src_ptr, sizeof(T)*n);
@@ -37,21 +37,20 @@
  * });
  *
  *
- * // Within the command group you can
- * //    1. Declare an accessor to a buffer
- *          auto read_write_acc = sycl::accessor{buf, cgh};
- *          auto read_acc = sycl::accessor{buf, cgh, sycl::read_only};
- *          auto write_acc = sycl::accessor{buf, cgh, sycl::write_only};
- *          auto no_init_acc = sycl::accessor{buf, cgh, sycl::no_init};
- * //    2. Enqueue a parallel for:
- * //             i: With range:
- *                    cgh.parallel_for<class mykernel>(sycl::range{n},
- *                    [=](sycl::id<1> i) { // Do something });
- * //             ii: With nd_range:
- *                    cgh.parallel_for<class mykernel>(sycl::nd_range{
- *                        globalRange, localRange}, [=](sycl::nd_item<1> i) {
- *                        // Do something
- *                      });
+ * // You can declare a parallel_for:
+ * //    1. Within a command group
+ *          auto event = q.submit([&](sycl::handler &cgh) {
+ *            cgh.parallel_for<class mykernel>(sycl::range{n}, kernelFunc
+ *          });
+ * //    2. Using a shortcut to the command group handler
+ *          auto event = queue.parallel_for<class mykernel>(sycl::range{n}, kernelFunc);
+ * // A parallel for can be enqueued:
+ * //    i:  With range:
+ *              parallel_for<class mykernel>(sycl::range{n},
+ *                  [=](sycl::id<1> i) { // Do something });
+ * //    ii: With nd_range:
+ *              parallel_for<class mykernel>(sycl::nd_range{globalRange, localRange},
+ *                  [=](sycl::nd_item<1> i) { // Do something });
 */
 
 #define CATCH_CONFIG_MAIN

--- a/Lesson_Materials/Introduction_to_SYCL/index.html
+++ b/Lesson_Materials/Introduction_to_SYCL/index.html
@@ -109,7 +109,7 @@
 					</div>
 				</section>
 
-        <!--Slide 8-->
+        		<!--Slide 6-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL System Topology
@@ -119,7 +119,7 @@
 						* The devices that are available in any given system are determined at runtime through topology discovery.
 					</div>
 				</section>
-				<!--Slide 9-->
+				<!--Slide 7-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Platforms and devices
@@ -134,7 +134,7 @@
 						![SYCL](../common-revealjs/images/devices-1.png "SYCL-Devices")
 					</div>
 				</section>
-        <!--Slide 10-->
+       			<!--Slide 8-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Querying with a device selector
@@ -151,7 +151,7 @@
 						</div>
 					</div>
 				</section>
-				<!--Slide 11-->
+				<!--Slide 9-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Querying with a device selector
@@ -172,7 +172,7 @@ auto gpuDevice = device(gpu_selector_v);
 							* A device with a negative score will never be chosen.
 					</div>
 				</section>
-        <!--Slide 12-->
+        		<!--Slide 10-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL Queues
@@ -188,7 +188,7 @@ auto gpuDevice = device(gpu_selector_v);
 						</div>
 					</div>
 				</section>
-				<!--Slide 13-->
+				<!--Slide 11-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### In-of-order execution
@@ -203,7 +203,7 @@ auto gpuDevice = device(gpu_selector_v);
 						</div>
 					</div>
 				</section>
-        <!--Slide 14-->
+        		<!--Slide 12-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Memory Models
@@ -215,7 +215,7 @@ auto gpuDevice = device(gpu_selector_v);
 						* Which model you choose can have an effect on how you enqueue kernel functions.
 					</div>
 				</section>
-				<!--Slide 15-->
+				<!--Slide 13-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### CPU and GPU Memory
@@ -230,7 +230,7 @@ auto gpuDevice = device(gpu_selector_v);
 					</div>
 					<img src="../common-revealjs/images/gpu_cpu_memory.png" height="400">
 				</section>
-        <!--Slide 16-->
+        		<!--Slide 14-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL Buffers & Accessors
@@ -243,7 +243,7 @@ auto gpuDevice = device(gpu_selector_v);
 						  * This means they are declared in the host code but captured by and then accessed within a SYCL kernel function
 					</div>
 				</section>
-				<!--Slide 17-->
+				<!--Slide 15-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL Buffers & Accessors
@@ -258,7 +258,7 @@ auto gpuDevice = device(gpu_selector_v);
 						</div>
 					</div>
 				</section>
-				<!--Slide 18-->
+				<!--Slide 16-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL Buffers & Accessors
@@ -273,7 +273,7 @@ auto gpuDevice = device(gpu_selector_v);
 						</div>
 					</div>
 				</section>
-				<!--Slide 19-->
+				<!--Slide 17-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Accessing Data With Accessors
@@ -303,7 +303,7 @@ gpuQueue.submit([&](handler &cgh){
 						</div>
 					</div>
 				</section>
-				<!--Slide 20-->
+				<!--Slide 18-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### USM: Malloc_device
@@ -324,7 +324,7 @@ T* malloc_device(size_t count, const queue& syclQueue,  const property_list &pro
 						* This is a blocking operation.
 					</div>
 				</section>
-				<!--Slide 22-->
+				<!--Slide 19-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### USM: Free
@@ -340,7 +340,7 @@ void free(void* ptr, queue& syclQueue);
 						* This is a blocking operation.
 					</div>
 				</section>
-				<!--Slide 23-->
+				<!--Slide 20-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### USM: Memcpy
@@ -358,7 +358,26 @@ event queue::memcpy(void* dest, const void* src, size_t numBytes, const std::vec
 						* May depend on other events via `depEvents`
 					</div>
 				</section>
-				<!--Slide 24-->
+				<!--Slide 21-->
+				<section>
+					<div class="hbox" data-markdown>
+						#### USM: Malloc_shared
+					</div>
+					<div class="container">
+						<code class="code-100pc"><pre>
+void* malloc_shared(size_t numBytes, const queue& syclQueue, const property_list& propList = {})
+
+template &lt;typename T&gt;
+T* malloc_shared(size_t count, const queue& syclQueue, const property_list& propList = {})
+						</code></pre>
+					</div>
+					<div class="container" data-markdown>
+						* A USM shared allocation is performed by calling one of the `malloc_shared` functions.
+						* Shared allocations implicitly share data between the host and devices; the runtime and backends ensure the data is available when used.
+						* Performance hints may be specified by enqueueing `prefetch` operations
+					</div>
+				</section>
+				<!--Slide 22-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL execution model
@@ -376,7 +395,7 @@ event queue::memcpy(void* dest, const void* src, size_t numBytes, const std::vec
 
 					</div>
 				</section>
-				<!--Slide 25-->
+				<!--Slide 23-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL execution model
@@ -392,7 +411,7 @@ event queue::memcpy(void* dest, const void* src, size_t numBytes, const std::vec
 						</div>
 					</div>
 				</section>
-				<!--Slide 26-->
+				<!--Slide 24-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL execution model
@@ -408,7 +427,7 @@ event queue::memcpy(void* dest, const void* src, size_t numBytes, const std::vec
 						</div>
 					</div>
 				</section>
-				<!--Slide 27-->
+				<!--Slide 25-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL execution model
@@ -426,7 +445,7 @@ event queue::memcpy(void* dest, const void* src, size_t numBytes, const std::vec
 						</div>
 					</div>
 				</section>
-				<!--Slide 28-->
+				<!--Slide 26-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Expressing parallelism
@@ -467,7 +486,7 @@ cgh.parallel_for&ltkernel&gt(nd_range&lt1&gt(<mark>range&lt1&gt(1024),
 						</div>
 					</div>
 				</section>
-				<!--Slide 30-->
+				<!--Slide 27-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL Kernels
@@ -483,7 +502,7 @@ cgh.parallel_for&ltkernel&gt(nd_range&lt1&gt(<mark>range&lt1&gt(1024),
 						// glue it all together from scratch
 					</div>
 				</section>
-				<!--Slide 31-->
+				<!--Slide 28-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Function object
@@ -509,7 +528,7 @@ class MyKernel {
              operator.
 					</div>
 				</section>
-				<!--Slide 32-->
+				<!--Slide 29-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Lambda function
@@ -534,7 +553,7 @@ handler.parallel_for(range, func);
             the kernel.
 					</div>
 				</section>
-				<!--Slide 33-->
+				<!--Slide 30-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL Kernels
@@ -548,7 +567,7 @@ handler.parallel_for(range, func);
             * Can be used to index into accessors, pointers etc.
 					</div>
 				</section>
-				<!--Slide 34-->
+				<!--Slide 31-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### First Exercise
@@ -562,7 +581,7 @@ handler.parallel_for(range, func);
 
 					</div>
 				</section>
-								<!--Slide 6-->
+				<!--Slide 32-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Image convolution sample application
@@ -576,7 +595,7 @@ handler.parallel_for(range, func);
 						* A lot of data must be passed through the GPU to process an image, particularly if the image is very high resolution.
 					</div>
 				</section>
-				<!--Slide 7-->
+				<!--Slide 33-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Image convolution definition
@@ -593,7 +612,7 @@ handler.parallel_for(range, func);
 						</div>
 					</div>
 				</section>
-				<!--Slide 35-->
+				<!--Slide 34-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Image convolution example
@@ -602,7 +621,7 @@ handler.parallel_for(range, func);
 						![SYCL](../common-revealjs/images/image_convolution_example.png "SYCL")
 					</div>
 				</section>
-				<!--Slide 36-->
+				<!--Slide 35-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Image convolution data flow
@@ -619,7 +638,7 @@ handler.parallel_for(range, func);
 						</div>
 					</div>
 				</section>
-				<!--Slide 37-->
+				<!--Slide 36-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Gaussian Blur
@@ -634,7 +653,7 @@ handler.parallel_for(range, func);
             * A dscrete convolution, in other words
 					</div>
 				</section>
-				<!--Slide 38-->
+				<!--Slide 37-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Walkthrough
@@ -644,7 +663,7 @@ handler.parallel_for(range, func);
             * Solution available in `Code_Exercises/Image_Convolution_Functors/solution.cpp`
 					</div>
 				</section>
-				<!--Slide 39-->
+				<!--Slide 38-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Reference image
@@ -660,7 +679,7 @@ handler.parallel_for(range, func);
 * The read and write functions can be found in `image_conv.h`.
 					</div>
 				</section>
-				<!--Slide 40-->
+				<!--Slide 39-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Convolution filters

--- a/Lesson_Materials/ND_Range_Kernel/index.html
+++ b/Lesson_Materials/ND_Range_Kernel/index.html
@@ -40,7 +40,7 @@
 				}
 			})();
 		</script>
-		
+
 	</head>
 	<body>
 		<div class="reveal">
@@ -198,7 +198,7 @@
 						</div>
 					</div>
 				</section>
-				<!--Slide 12-->
+				<!--Slide 11-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL execution model
@@ -213,7 +213,7 @@
 						</div>
 					</div>
 				</section>
-				<!--Slide 14-->
+				<!--Slide 12-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL memory model
@@ -229,7 +229,7 @@
 
 					</div>
 				</section>
-				<!--Slide 15-->
+				<!--Slide 13-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL memory model
@@ -244,7 +244,7 @@
 						</div>
 					</div>
 				</section>
-				<!--Slide 16-->
+				<!--Slide 14-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL memory model
@@ -260,14 +260,14 @@
 
 					</div>
 				</section>
-				<!--Slide 17-->
+				<!--Slide 15-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### SYCL memory model
 					</div>
 					<div class="container">
 						<div class="col" data-markdown>
-							* Each memory region has a different size and access latency 
+							* Each memory region has a different size and access latency
 							* Global / constant memory is larger than local memory and local memory is larger than private memory
 							* Private memory is faster than local memory and local memory is faster than global / constant memory
 						</div>
@@ -276,7 +276,7 @@
 						</div>
 					</div>
 				</section>
-				<!--Slide 19-->
+				<!--Slide 16-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Expressing parallelism
@@ -284,22 +284,22 @@
 					<div class="container">
 						<div class="col">
 							<code><pre>
-							
-cgh.parallel_for&ltkernel&gt(<mark>range&lt1&gt(1024)</mark>, 
+
+cgh.parallel_for&ltkernel&gt(<mark>range&lt1&gt(1024)</mark>,
   [=](<mark>id&lt1&gt idx</mark>){
     /* kernel function code */
 });
 							</code></pre>
 							<code><pre>
-							
-cgh.parallel_for&ltkernel&gt(<mark>range&lt1&gt(1024)</mark>, 
+
+cgh.parallel_for&ltkernel&gt(<mark>range&lt1&gt(1024)</mark>,
   [=](<mark>item&lt1&gt item</mark>){
     /* kernel function code */
 });
 							</code></pre>
 							<code><pre>
-							
-cgh.parallel_for&ltkernel&gt(nd_range&lt1&gt(<mark>range&lt1&gt(1024), 
+
+cgh.parallel_for&ltkernel&gt(nd_range&lt1&gt(<mark>range&lt1&gt(1024),
   range&lt1&gt(32))</mark>,[=](<mark>nd_item&lt1&gt ndItem</mark>){
     /* kernel function code */
 });
@@ -310,102 +310,118 @@ cgh.parallel_for&ltkernel&gt(nd_range&lt1&gt(<mark>range&lt1&gt(1024),
 							* An **id** parameter represents the index within the global range
 							____________________________________________________________________________________________
 							* Overload taking a **range** object specifies the global range, runtime decides local range
-							* An **item** parameter represents the global range and the index within the global range
+							* An **item** parameter represents the index within the global range and the global range
 							____________________________________________________________________________________________
 							* Overload taking an **nd_range** object specifies the global and local range
-							* An **nd_item** parameter represents the global and local range and index
+							* An **nd_item** parameter represents the index, global range, and local range
 						</div>
 					</div>
 				</section>
-				<!--Slide 22-->
+				<!--Slide 17-->
 				<section>
 					<div class="hbox" data-markdown>
-						#### Accessing Data With Accessors
-					</div>
-					<div class="container" data-markdown>
-					* There are a few different ways to access the data represented by an accessor
-					  *  The subscript operator can take an **id**
-					    * Must be the same dimensionality of the accessor
-					    * For dimensions > 1, linear address is calculated in row major 
-					* Nested subscript operators can be called for each dimension taking a **size_t**
-					  * E.g. a 3-dimensional accessor: acc[x][y][z] = …
-					* A pointer to memory can be retrieved by calling **get_pointer**
-					  * This returns a raw pointer to the data
-					</div>
-				</section>
-				<!--Slide 23-->
-				<section>
-					<div class="hbox" data-markdown>
-						#### Accessing Data With Accessors
+						#### Accessing Data With USM Device Pointers
 					</div>
 					<div class="container">
 						<div class="col-left-3">
 							<code><pre>
-buffer&ltfloat, 1&gt bufA(dA.data(), range&lt1&gt(dA.size())); 
-buffer&ltfloat, 1&gt bufB(dB.data(), range&lt1&gt(dB.size())); 
-buffer&ltfloat, 1&gt bufO(dO.data(), range&lt1&gt(dO.size()));
+auto ptrA = sycl::malloc_device&ltfloat&gt(dA.size(), queue);
+auto ptrB = sycl::malloc_device&ltfloat&gt(dB.size(), queue);
+auto ptrO = sycl::malloc_device&ltfloat&gt(dO.size(), queue);
 
-gpuQueue.submit([&](handler &cgh){
-  sycl::accessor inA{bufA, cgh, sycl::read_only};
-  sycl::accessor inB{bufB, cgh, sycl::read_only};
-  sycl::accessor out{bufO, cgh, sycl::write_only};
-  cgh.parallel_for&ltadd&gt(range&lt1&gt(dA.size()), 
-    [=](id&lt1&gt i){ 
-    <mark>out[i] = inA[i] + inB[i];</mark>
-  });
+queue.memcpy(ptrA, dA.data(), sizeof(int) * dA.size()).wait();
+queue.memcpy(ptrB, dB.data(), sizeof(int) * dB.size()).wait();
+
+queue.parallel_for&ltadd&gt(range&lt1&gt(dO.size()),
+    [=](<mark>id&lt1&gt i</mark>){
+    	<mark>ptrO[i] = ptrA[i] + ptrB[i];</mark>
 });
+
+queue.memcpy(dO.data, ptrO, sizeof(int) * dO.size()).wait();
 							</code></pre>
 						</div>
 						<div class="col-right-2" data-markdown>
-							* Here we access the data of the `accessor` by
+							* Here we access the data of the `device pointer` by
 							passing in the `id` passed to the SYCL kernel
 							function.
 						</div>
 					</div>
 				</section>
-				<!--Slide 24-->
+				<!--Slide 18-->
 				<section>
 					<div class="hbox" data-markdown>
-						#### Accessing Data With Accessors
+						#### Accessing Data With USM Device Pointers
 					</div>
 					<div class="container">
 						<div class="col-left-3">
 							<code><pre>
-buffer&ltfloat, 1&gt bufA(dA.data(), range&lt1&gt(dA.size())); 
-buffer&ltfloat, 1&gt bufB(dB.data(), range&lt1&gt(dB.size())); 
-buffer&ltfloat, 1&gt bufO(dO.data(), range&lt1&gt(dO.size()));
+auto ptrA = sycl::malloc_device&ltfloat&gt(dA.size(), queue);
+auto ptrB = sycl::malloc_device&ltfloat&gt(dB.size(), queue);
+auto ptrO = sycl::malloc_device&ltfloat&gt(dO.size(), queue)
 
-gpuQueue.submit([&](handler &cgh){
-  sycl::accessor inA{bufA, cgh, sycl::read_only};
-  sycl::accessor inB{bufB, cgh, sycl::read_only};
-  sycl::accessor out{bufO, cgh, sycl::write_only};
-  cgh.parallel_for&ltadd&gt(rng, [=](item&lt3&gt i){
-    <mark>auto ptrA = inA.get_pointer();</mark>
-    <mark>auto ptrB = inB.get_pointer();</mark>
-    <mark>auto ptrO = out.get_pointer();</mark>
-    <mark>auto linearId = i.get_linear_id();</mark>
+queue.memcpy(ptrA, dA, sizeof(int) * dA.size()).wait();
+queue.memcpy(ptrB, dB, sizeof(int) * dB.size()).wait();
 
-    <mark>ptrA[linearId] = ptrB[linearId] + ptrO[linearId]; </mark>
-  });
+size_t sizeSqrt = std::sqrt(dO.size());
+auto rng = sycl::range<2>{sizeSqrt, sizeSqrt};
+
+queue.parallel_for&ltadd&gt(rng, [=](<mark>item&lt2&gt itm</mark>){
+    <mark>auto linearId = itm.get_linear_id();</mark>
+    <mark>ptrO[linearId] = ptrA[linearId] + ptrB[linearId]; </mark>
 });
+
+queue.memcpy(dO.data, ptrO, sizeof(int) * dO.size()).wait();
 							</code></pre>
 						</div>
 						<div class="col-right-2" data-markdown>
-							* Here we retrieve the underlying pointer for each
-							of the `accessor`s.
-							* We then access the pointer using the linearized
+							* Here we access the pointer using the linearized
 							`id` by calling the `get_linear_id` member function
 							on the `item`.
-							* Again this linearization is calculated in
+							* This linearization is calculated in
 							row-major order.
 						</div>
 					</div>
 				</section>
-				<!--Slide 25-->
+				<!--Slide 19-->
+				<section>
+					<div class="hbox" data-markdown>
+						#### Accessing Data With USM Device Pointers
+					</div>
+					<div class="container">
+						<div class="col-left-3">
+							<code><pre>
+auto ptrA = sycl::malloc_device&ltfloat&gt(dA.size(), queue);
+auto ptrB = sycl::malloc_device&ltfloat&gt(dB.size(), queue);
+auto ptrO = sycl::malloc_device&ltfloat&gt(dO.size(), queue)
+
+queue.memcpy(ptrA, dA, sizeof(int) * dA.size()).wait();
+queue.memcpy(ptrB, dB, sizeof(int) * dB.size()).wait();
+
+auto ndRange = sycl::nd_range{sycl::range{dO.size()},
+                              sycl::range{workGroupSize}};
+
+queue.parallel_for&ltadd&gt(ndRange, [=](<mark>nd_item&lt1&gt itm</mark>){
+    <mark>auto globalId = itm.get_global_id();</mark>
+    <mark>ptrO[globalId] = ptrA[globalId] + ptrB[globalId]; </mark>
+});
+
+queue.memcpy(dO.data, ptrO, sizeof(int) * dO.size()).wait();
+							</code></pre>
+						</div>
+						<div class="col-right-2" data-markdown>
+							* Here we access the pointer using the global
+							`id` by calling the `get_global_id` member function
+							on the `nd_item`.
+							* Again, this linearization is calculated in
+							row-major order.
+						</div>
+					</div>
+				</section>
+				<!--Slide 20-->
 				<section class="hbox" data-markdown>
 					## Questions
 				</section>
-				<!--Slide 26-->
+				<!--Slide 21-->
 				<section>
 					<div class="hbox" data-markdown>
 						#### Exercise

--- a/Lesson_Materials/ND_Range_Kernel/index.html
+++ b/Lesson_Materials/ND_Range_Kernel/index.html
@@ -320,28 +320,19 @@ cgh.parallel_for&ltkernel&gt(nd_range&lt1&gt(<mark>range&lt1&gt(1024),
 				<!--Slide 17-->
 				<section>
 					<div class="hbox" data-markdown>
-						#### Accessing Data With USM Device Pointers
+						#### Accessing Data With Different Ranges
 					</div>
 					<div class="container">
 						<div class="col-left-3">
 							<code><pre>
-auto ptrA = sycl::malloc_device&ltfloat&gt(dA.size(), queue);
-auto ptrB = sycl::malloc_device&ltfloat&gt(dB.size(), queue);
-auto ptrO = sycl::malloc_device&ltfloat&gt(dO.size(), queue);
-
-queue.memcpy(ptrA, dA.data(), sizeof(int) * dA.size()).wait();
-queue.memcpy(ptrB, dB.data(), sizeof(int) * dB.size()).wait();
-
-queue.parallel_for&ltadd&gt(range&lt1&gt(dO.size()),
+queue.parallel_for&ltadd&gt(range&lt1&gt(dataSize),
     [=](<mark>id&lt1&gt i</mark>){
     	<mark>ptrO[i] = ptrA[i] + ptrB[i];</mark>
 });
-
-queue.memcpy(dO.data, ptrO, sizeof(int) * dO.size()).wait();
 							</code></pre>
 						</div>
 						<div class="col-right-2" data-markdown>
-							* Here we access the data of the `device pointer` by
+							* Here we access the data of a `USM pointer` by
 							passing in the `id` passed to the SYCL kernel
 							function.
 						</div>
@@ -350,27 +341,18 @@ queue.memcpy(dO.data, ptrO, sizeof(int) * dO.size()).wait();
 				<!--Slide 18-->
 				<section>
 					<div class="hbox" data-markdown>
-						#### Accessing Data With USM Device Pointers
+						#### Accessing Data With Different Ranges
 					</div>
 					<div class="container">
 						<div class="col-left-3">
 							<code><pre>
-auto ptrA = sycl::malloc_device&ltfloat&gt(dA.size(), queue);
-auto ptrB = sycl::malloc_device&ltfloat&gt(dB.size(), queue);
-auto ptrO = sycl::malloc_device&ltfloat&gt(dO.size(), queue)
-
-queue.memcpy(ptrA, dA, sizeof(int) * dA.size()).wait();
-queue.memcpy(ptrB, dB, sizeof(int) * dB.size()).wait();
-
-size_t sizeSqrt = std::sqrt(dO.size());
+size_t sizeSqrt = std::sqrt(dataSize);
 auto rng = sycl::range<2>{sizeSqrt, sizeSqrt};
-
+	
 queue.parallel_for&ltadd&gt(rng, [=](<mark>item&lt2&gt itm</mark>){
     <mark>auto linearId = itm.get_linear_id();</mark>
     <mark>ptrO[linearId] = ptrA[linearId] + ptrB[linearId]; </mark>
 });
-
-queue.memcpy(dO.data, ptrO, sizeof(int) * dO.size()).wait();
 							</code></pre>
 						</div>
 						<div class="col-right-2" data-markdown>
@@ -385,27 +367,18 @@ queue.memcpy(dO.data, ptrO, sizeof(int) * dO.size()).wait();
 				<!--Slide 19-->
 				<section>
 					<div class="hbox" data-markdown>
-						#### Accessing Data With USM Device Pointers
+						#### Accessing Data With Different Ranges
 					</div>
 					<div class="container">
 						<div class="col-left-3">
 							<code><pre>
-auto ptrA = sycl::malloc_device&ltfloat&gt(dA.size(), queue);
-auto ptrB = sycl::malloc_device&ltfloat&gt(dB.size(), queue);
-auto ptrO = sycl::malloc_device&ltfloat&gt(dO.size(), queue)
-
-queue.memcpy(ptrA, dA, sizeof(int) * dA.size()).wait();
-queue.memcpy(ptrB, dB, sizeof(int) * dB.size()).wait();
-
-auto ndRange = sycl::nd_range{sycl::range{dO.size()},
+auto ndRange = sycl::nd_range{sycl::range{dataSize},
                               sycl::range{workGroupSize}};
 
 queue.parallel_for&ltadd&gt(ndRange, [=](<mark>nd_item&lt1&gt itm</mark>){
     <mark>auto globalId = itm.get_global_id();</mark>
     <mark>ptrO[globalId] = ptrA[globalId] + ptrB[globalId]; </mark>
 });
-
-queue.memcpy(dO.data, ptrO, sizeof(int) * dO.size()).wait();
 							</code></pre>
 						</div>
 						<div class="col-right-2" data-markdown>


### PR DESCRIPTION
- Remove compilation of nonexistent directory `OneMKL_gemm`
- Modified the quick reference in the exercise source: mention device pointers instead of buffers. Also added an example of declaration of  `parallel_for` with and without command group handler 
- Modified the exercise solution to use USM device pointers 
- Modified the "Accessing Data With Accessors" slides to use USM device pointers and showcase accessing data with `id/item/nd_item`
- Changed word ordering on "Expressing parallelism" slide to make it easier to distinguish the differences between `id/item/nd_item`