### PR TITLE
Remove catch2 dependency and add clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: LLVM

--- a/.clang-format
+++ b/.clang-format
@@ -1,1 +1,8 @@
+Language: Cpp
 BasedOnStyle: LLVM
+AccessModifierOffset: -1
+BreakInheritanceList: BeforeComma
+BreakConstructorInitializers: BeforeComma
+Cpp11BracedListStyle: false
+PointerAlignment: Left
+SpaceBeforeCpp11BracedList: true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,7 +110,6 @@ endif()
 # Exercises
 
 enable_testing()
-add_subdirectory(External/Catch2)
 add_subdirectory(Code_Exercises)
 
 # Create the Image directory

--- a/Code_Exercises/Advanced_Data_Flow/solution.cpp
+++ b/Code_Exercises/Advanced_Data_Flow/solution.cpp
@@ -18,7 +18,8 @@ class kernel_b_2;
 
 int usm_selector(const sycl::device& dev) {
   if (dev.has(sycl::aspect::usm_device_allocations)) {
-    if (dev.has(sycl::aspect::gpu)) return 2;
+    if (dev.has(sycl::aspect::gpu))
+      return 2;
     return 1;
   }
   return -1;
@@ -34,31 +35,31 @@ void test_buffer() {
   }
 
   try {
-    auto gpuQueue = sycl::queue{sycl::gpu_selector_v};
+    auto gpuQueue = sycl::queue { sycl::gpu_selector_v };
 
-    auto bufIn = sycl::buffer{in, sycl::range{dataSize}};
-    auto bufInt = sycl::buffer<float>{sycl::range{dataSize}};
-    auto bufOut = sycl::buffer<float>{sycl::range{dataSize}};
+    auto bufIn = sycl::buffer { in, sycl::range { dataSize } };
+    auto bufInt = sycl::buffer<float> { sycl::range { dataSize } };
+    auto bufOut = sycl::buffer<float> { sycl::range { dataSize } };
 
     bufIn.set_final_data(nullptr);
     bufOut.set_final_data(out);
 
     gpuQueue.submit([&](sycl::handler& cgh) {
-      sycl::accessor accIn{bufIn, cgh, sycl::read_only};
-      sycl::accessor accOut{bufInt, cgh, sycl::write_only};
+      sycl::accessor accIn { bufIn, cgh, sycl::read_only };
+      sycl::accessor accOut { bufInt, cgh, sycl::write_only };
 
-      cgh.parallel_for<kernel_a_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
-        accOut[idx] = accIn[idx] * 8.0f;
-      });
+      cgh.parallel_for<kernel_a_1>(
+          sycl::range { dataSize },
+          [=](sycl::id<1> idx) { accOut[idx] = accIn[idx] * 8.0f; });
     });
 
     gpuQueue.submit([&](sycl::handler& cgh) {
-      sycl::accessor accIn{bufInt, cgh, sycl::read_only};
-      sycl::accessor accOut{bufOut, cgh, sycl::write_only};
+      sycl::accessor accIn { bufInt, cgh, sycl::read_only };
+      sycl::accessor accOut { bufOut, cgh, sycl::write_only };
 
-      cgh.parallel_for<kernel_b_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
-        accOut[idx] = accIn[idx] / 2.0f;
-      });
+      cgh.parallel_for<kernel_b_1>(
+          sycl::range { dataSize },
+          [=](sycl::id<1> idx) { accOut[idx] = accIn[idx] / 2.0f; });
     });
 
     gpuQueue.wait_and_throw();
@@ -81,7 +82,7 @@ void test_usm() {
   }
 
   try {
-    auto usmQueue = sycl::queue{usm_selector};
+    auto usmQueue = sycl::queue { usm_selector };
 
     auto devicePtrIn = sycl::malloc_device<float>(dataSize, usmQueue);
     auto devicePtrInt = sycl::malloc_device<float>(dataSize, usmQueue);
@@ -90,13 +91,13 @@ void test_usm() {
     auto e1 = usmQueue.memcpy(devicePtrIn, in, sizeof(float) * dataSize);
 
     auto e2 = usmQueue.parallel_for<kernel_a_2>(
-        sycl::range{dataSize}, e1, [=](sycl::id<1> idx) {
+        sycl::range { dataSize }, e1, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrInt[globalId] = devicePtrIn[globalId] * 8.0f;
         });
 
     auto e3 = usmQueue.parallel_for<kernel_b_2>(
-        sycl::range{dataSize}, e2, [=](sycl::id<1> idx) {
+        sycl::range { dataSize }, e2, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrOut[globalId] = devicePtrInt[globalId] / 2.0f;
         });

--- a/Code_Exercises/Advanced_Data_Flow/solution.cpp
+++ b/Code_Exercises/Advanced_Data_Flow/solution.cpp
@@ -10,8 +10,6 @@
 
 //#define SYCL_ACADEMY_USING_COMPUTECPP
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
 
 #include <sycl/sycl.hpp>
 
@@ -28,7 +26,7 @@ int usm_selector(const sycl::device& dev) {
   return -1;
 }
 
-TEST_CASE("buffer_accessor_temporary_data", "temporary_data_solution") {
+void test_buffer() {
   constexpr size_t dataSize = 1024;
 
   float in[dataSize], out[dataSize];
@@ -71,11 +69,11 @@ TEST_CASE("buffer_accessor_temporary_data", "temporary_data_solution") {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    REQUIRE(out[i] == i * 4.0f);
+    assert(out[i] == i * 4.0f);
   }
 }
 
-TEST_CASE("usm_temporary_data", "temporary_data_solution") {
+void test_usm() {
   constexpr size_t dataSize = 1024;
 
   float in[dataSize], out[dataSize];
@@ -122,6 +120,11 @@ TEST_CASE("usm_temporary_data", "temporary_data_solution") {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    REQUIRE(out[i] == i * 4.0f);
+    assert(out[i] == i * 4.0f);
   }
+}
+
+int main() {
+  test_usm();
+  test_buffer();
 }

--- a/Code_Exercises/Advanced_Data_Flow/solution.cpp
+++ b/Code_Exercises/Advanced_Data_Flow/solution.cpp
@@ -8,9 +8,7 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-//#define SYCL_ACADEMY_USING_COMPUTECPP
-
-
+#include "../helpers.hpp"
 #include <sycl/sycl.hpp>
 
 class kernel_a_1;
@@ -69,7 +67,7 @@ void test_buffer() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(out[i] == i * 4.0f);
+    SYCLACADEMY_ASSERT(out[i] == i * 4.0f);
   }
 }
 
@@ -120,7 +118,7 @@ void test_usm() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(out[i] == i * 4.0f);
+    SYCLACADEMY_ASSERT(out[i] == i * 4.0f);
   }
 }
 

--- a/Code_Exercises/Advanced_Data_Flow/source.cpp
+++ b/Code_Exercises/Advanced_Data_Flow/source.cpp
@@ -41,16 +41,17 @@
  *          auto write_acc = sycl::accessor{buf, cgh, sycl::write_only};
  *          auto no_init_acc = sycl::accessor{buf, cgh, sycl::no_init};
  * //    2. Enqueue a parallel for:
- *          cgh.parallel_for<class mykernel>(sycl::range{n}, [=](sycl::id<1> i) {
+ *          cgh.parallel_for<class mykernel>(sycl::range{n}, [=](sycl::id<1> i)
+ {
  *              // Do something
  *          });
  *
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
+#include <cstddef>
 
-TEST_CASE("temporary_data", "temporary_data_source") {
+int main() {
   constexpr size_t dataSize = 1024;
 
   float in[dataSize], out[dataSize], tmp[dataSize];
@@ -60,13 +61,13 @@ TEST_CASE("temporary_data", "temporary_data_source") {
     out[i] = 0.0f;
   }
 
-  // Task: run these kernels on a SYCL device, minimising the memory transfers between the host and device
+  // Task: run these kernels on a SYCL device, minimising the memory transfers
+  // between the host and device
 
   // Kernel A
   for (int i = 0; i < dataSize; ++i) {
     tmp[i] = in[i] * 8.0f;
   }
-
 
   // Kernel B
   for (int i = 0; i < dataSize; ++i) {
@@ -74,6 +75,6 @@ TEST_CASE("temporary_data", "temporary_data_source") {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    REQUIRE(out[i] == i * 4.0f);
+    assert(out[i] == i * 4.0f);
   }
 }

--- a/Code_Exercises/Advanced_Data_Flow/source.cpp
+++ b/Code_Exercises/Advanced_Data_Flow/source.cpp
@@ -48,8 +48,7 @@
  *
 */
 
-#include <cassert>
-#include <cstddef>
+#include "../helpers.hpp"
 
 int main() {
   constexpr size_t dataSize = 1024;
@@ -75,6 +74,6 @@ int main() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(out[i] == i * 4.0f);
+    SYCLACADEMY_ASSERT(out[i] == i * 4.0f);
   }
 }

--- a/Code_Exercises/Asynchronous_Execution/solution.cpp
+++ b/Code_Exercises/Asynchronous_Execution/solution.cpp
@@ -8,6 +8,7 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
 #include <sycl/sycl.hpp>
 
 class vector_add_1;
@@ -61,7 +62,7 @@ void test_buffer_event_wait() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(r[i] == i * 2);
+    SYCLACADEMY_ASSERT(r[i] == i * 2);
   }
 }
 
@@ -98,7 +99,7 @@ void test_buffer_queue_wait() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(r[i] == i * 2);
+    SYCLACADEMY_ASSERT(r[i] == i * 2);
   }
 }
 
@@ -137,7 +138,7 @@ void test_buffer_buffer_destruction() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(r[i] == i * 2);
+    SYCLACADEMY_ASSERT(r[i] == i * 2);
   }
 }
 
@@ -189,7 +190,7 @@ void test_usm_event_wait() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(r[i] == i * 2);
+    SYCLACADEMY_ASSERT(r[i] == i * 2);
   }
 }
 
@@ -239,7 +240,7 @@ void test_usm_queue_wait() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(r[i] == i * 2);
+    SYCLACADEMY_ASSERT(r[i] == i * 2);
   }
 }
 
@@ -277,7 +278,7 @@ void test_buffer_host_accessor() {
         auto hostAccR = bufR.get_host_access(sycl::read_only); // Copy-to-host
 
         for (int i = 0; i < dataSize; ++i) {
-          assert(hostAccR[i] == i * 2);
+          SYCLACADEMY_ASSERT(hostAccR[i] == i * 2);
         }
       }
 

--- a/Code_Exercises/Asynchronous_Execution/solution.cpp
+++ b/Code_Exercises/Asynchronous_Execution/solution.cpp
@@ -18,7 +18,7 @@ class vector_add_4;
 class vector_add_5;
 class vector_add_6;
 
-int usm_selector(const sycl::device &dev) {
+int usm_selector(const sycl::device& dev) {
   if (dev.has(sycl::aspect::usm_device_allocations)) {
     if (dev.has(sycl::aspect::gpu))
       return 2;
@@ -38,26 +38,26 @@ void test_buffer_event_wait() {
   }
 
   try {
-    auto defaultQueue = sycl::queue{};
+    auto defaultQueue = sycl::queue {};
 
-    auto bufA = sycl::buffer{a, sycl::range{dataSize}};
-    auto bufB = sycl::buffer{b, sycl::range{dataSize}};
-    auto bufR = sycl::buffer{r, sycl::range{dataSize}};
+    auto bufA = sycl::buffer { a, sycl::range { dataSize } };
+    auto bufB = sycl::buffer { b, sycl::range { dataSize } };
+    auto bufR = sycl::buffer { r, sycl::range { dataSize } };
 
     defaultQueue
-        .submit([&](sycl::handler &cgh) {
-          auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
-          auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
-          auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
+        .submit([&](sycl::handler& cgh) {
+          auto accA = sycl::accessor { bufA, cgh, sycl::read_only };
+          auto accB = sycl::accessor { bufB, cgh, sycl::read_only };
+          auto accR = sycl::accessor { bufR, cgh, sycl::write_only };
 
           cgh.parallel_for<vector_add_1>(
-              sycl::range{dataSize},
+              sycl::range { dataSize },
               [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
         })
         .wait(); // Synchronize
 
     defaultQueue.throw_asynchronous();
-  } catch (const sycl::exception &e) { // Copy back
+  } catch (const sycl::exception& e) { // Copy back
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
@@ -77,24 +77,24 @@ void test_buffer_queue_wait() {
   }
 
   try {
-    auto defaultQueue = sycl::queue{};
+    auto defaultQueue = sycl::queue {};
 
-    auto bufA = sycl::buffer{a, sycl::range{dataSize}};
-    auto bufB = sycl::buffer{b, sycl::range{dataSize}};
-    auto bufR = sycl::buffer{r, sycl::range{dataSize}};
+    auto bufA = sycl::buffer { a, sycl::range { dataSize } };
+    auto bufB = sycl::buffer { b, sycl::range { dataSize } };
+    auto bufR = sycl::buffer { r, sycl::range { dataSize } };
 
-    defaultQueue.submit([&](sycl::handler &cgh) {
-      auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
-      auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
-      auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
+    defaultQueue.submit([&](sycl::handler& cgh) {
+      auto accA = sycl::accessor { bufA, cgh, sycl::read_only };
+      auto accB = sycl::accessor { bufB, cgh, sycl::read_only };
+      auto accR = sycl::accessor { bufR, cgh, sycl::write_only };
 
       cgh.parallel_for<vector_add_2>(
-          sycl::range{dataSize},
+          sycl::range { dataSize },
           [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
     });
 
     defaultQueue.wait_and_throw();     // Synchronize
-  } catch (const sycl::exception &e) { // Copy back
+  } catch (const sycl::exception& e) { // Copy back
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
@@ -114,26 +114,26 @@ void test_buffer_buffer_destruction() {
   }
 
   try {
-    auto defaultQueue = sycl::queue{};
+    auto defaultQueue = sycl::queue {};
 
     {
-      auto bufA = sycl::buffer{a, sycl::range{dataSize}};
-      auto bufB = sycl::buffer{b, sycl::range{dataSize}};
-      auto bufR = sycl::buffer{r, sycl::range{dataSize}};
+      auto bufA = sycl::buffer { a, sycl::range { dataSize } };
+      auto bufB = sycl::buffer { b, sycl::range { dataSize } };
+      auto bufR = sycl::buffer { r, sycl::range { dataSize } };
 
-      defaultQueue.submit([&](sycl::handler &cgh) {
-        auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
-        auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
-        auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
+      defaultQueue.submit([&](sycl::handler& cgh) {
+        auto accA = sycl::accessor { bufA, cgh, sycl::read_only };
+        auto accB = sycl::accessor { bufB, cgh, sycl::read_only };
+        auto accR = sycl::accessor { bufR, cgh, sycl::write_only };
 
         cgh.parallel_for<vector_add_3>(
-            sycl::range{dataSize},
+            sycl::range { dataSize },
             [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
       });
     } // Synchronize and copy-back
 
     defaultQueue.throw_asynchronous();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
@@ -153,7 +153,7 @@ void test_usm_event_wait() {
   }
 
   try {
-    auto usmQueue = sycl::queue{usm_selector};
+    auto usmQueue = sycl::queue { usm_selector };
 
     auto devicePtrA = sycl::malloc_device<float>(dataSize, usmQueue);
     auto devicePtrB = sycl::malloc_device<float>(dataSize, usmQueue);
@@ -167,7 +167,7 @@ void test_usm_event_wait() {
         .wait(); // Synchronize
 
     usmQueue
-        .parallel_for<vector_add_4>(sycl::range{dataSize},
+        .parallel_for<vector_add_4>(sycl::range { dataSize },
                                     [=](sycl::id<1> idx) {
                                       auto globalId = idx[0];
                                       devicePtrR[globalId] =
@@ -185,7 +185,7 @@ void test_usm_event_wait() {
     sycl::free(devicePtrR, usmQueue);
 
     usmQueue.throw_asynchronous();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
@@ -205,7 +205,7 @@ void test_usm_queue_wait() {
   }
 
   try {
-    auto usmQueue = sycl::queue{usm_selector};
+    auto usmQueue = sycl::queue { usm_selector };
 
     auto devicePtrA = sycl::malloc_device<float>(dataSize, usmQueue);
     auto devicePtrB = sycl::malloc_device<float>(dataSize, usmQueue);
@@ -217,7 +217,7 @@ void test_usm_queue_wait() {
     usmQueue.wait(); // Synchronize
 
     usmQueue.parallel_for<vector_add_5>(
-        sycl::range{dataSize}, [=](sycl::id<1> idx) {
+        sycl::range { dataSize }, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrR[globalId] = devicePtrA[globalId] + devicePtrB[globalId];
         });
@@ -235,7 +235,7 @@ void test_usm_queue_wait() {
     sycl::free(devicePtrR, usmQueue);
 
     usmQueue.throw_asynchronous();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
@@ -255,20 +255,20 @@ void test_buffer_host_accessor() {
   }
 
   try {
-    auto defaultQueue = sycl::queue{};
+    auto defaultQueue = sycl::queue {};
 
     {
-      auto bufA = sycl::buffer{a, sycl::range{dataSize}};
-      auto bufB = sycl::buffer{b, sycl::range{dataSize}};
-      auto bufR = sycl::buffer{r, sycl::range{dataSize}};
+      auto bufA = sycl::buffer { a, sycl::range { dataSize } };
+      auto bufB = sycl::buffer { b, sycl::range { dataSize } };
+      auto bufR = sycl::buffer { r, sycl::range { dataSize } };
 
-      defaultQueue.submit([&](sycl::handler &cgh) {
-        auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
-        auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
-        auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
+      defaultQueue.submit([&](sycl::handler& cgh) {
+        auto accA = sycl::accessor { bufA, cgh, sycl::read_only };
+        auto accB = sycl::accessor { bufB, cgh, sycl::read_only };
+        auto accR = sycl::accessor { bufR, cgh, sycl::write_only };
 
         cgh.parallel_for<vector_add_6>(
-            sycl::range{dataSize},
+            sycl::range { dataSize },
             [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
       });
 
@@ -285,7 +285,7 @@ void test_buffer_host_accessor() {
     } // Copy-back
 
     defaultQueue.throw_asynchronous();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 }

--- a/Code_Exercises/Asynchronous_Execution/source.cpp
+++ b/Code_Exercises/Asynchronous_Execution/source.cpp
@@ -44,16 +44,16 @@
  *
 */
 
-#include <cassert>
+#include "../helpers.hpp"
 
 void test_usm() {
   // Use your code from Exercise 3 to start
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }
 
 void test_buffer() {
   // Use your code from Exercise 3 to start
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }
 
 int main() {

--- a/Code_Exercises/Asynchronous_Execution/source.cpp
+++ b/Code_Exercises/Asynchronous_Execution/source.cpp
@@ -44,15 +44,19 @@
  *
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
 
-TEST_CASE("synchronization_usm", "synchronization_source") {
+void test_usm() {
   // Use your code from Exercise 3 to start
-  REQUIRE(true);
+  assert(true);
 }
 
-TEST_CASE("synchronization_buffer_acc", "synchronization_source") {
+void test_buffer() {
   // Use your code from Exercise 3 to start
-  REQUIRE(true);
+  assert(true);
+}
+
+int main() {
+  test_usm();
+  test_buffer();
 }

--- a/Code_Exercises/CMakeLists.txt
+++ b/Code_Exercises/CMakeLists.txt
@@ -19,7 +19,6 @@ function( add_sycl_executable_adaptivecpp prefix source )
     ${PROJECT_SOURCE_DIR}/Utilities/include
     ${PROJECT_SOURCE_DIR}/External/stb)
   target_link_libraries("${prefix}_${source}" PRIVATE Threads::Threads)
-  target_link_libraries("${prefix}_${source}" PUBLIC Catch2::Catch2)
   set_target_properties("${prefix}_${source}" PROPERTIES CXX_STANDARD 17 CXX_STANDARD_REQUIRED ON)
 endfunction()
 
@@ -31,10 +30,8 @@ function( add_sycl_executable_dpcpp prefix source )
   add_executable(${TARGET_NAME} "${source}.cpp")
   # This function is from IntelSYCL cmake module
   add_sycl_to_target(TARGET ${TARGET_NAME} SOURCES "${source}.cpp")
-  target_include_directories(${TARGET_NAME} PUBLIC "${CMAKE_SOURCE_DIR}/External/Catch2/single_include")
   target_include_directories(${TARGET_NAME} PUBLIC "${CMAKE_SOURCE_DIR}/External/stb")
   target_include_directories(${TARGET_NAME} PUBLIC "${CMAKE_SOURCE_DIR}/Utilities/include")
-  target_link_libraries(${TARGET_NAME} PUBLIC Catch2::Catch2)
 endfunction()
 
 function( add_sycl_executable prefix source )

--- a/Code_Exercises/Coalesced_Global_Memory/README.md
+++ b/Code_Exercises/Coalesced_Global_Memory/README.md
@@ -65,7 +65,7 @@ make Coalesced_Global_Memory_source
 ```
 Alternatively from a terminal at the command line:
 ```sh
-icpx -fsycl -o Coalesced_Global_Memory_source -I../External/Catch2/single_include ../Code_Exercises/Coalesced_Global_Memory/source.cpp
+icpx -fsycl -o Coalesced_Global_Memory_source ../Code_Exercises/Coalesced_Global_Memory/source.cpp
 ./Coalesced_Global_Memory_source
 ```
 
@@ -83,6 +83,6 @@ make Coalesced_Global_Memory_source
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/Coalesced_Global_Memory
-/path/to/adaptivecpp/bin/acpp -o Coalesced_Global_Memory_source -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o Coalesced_Global_Memory_source --acpp-targets="<target specification>" source.cpp
 ./Coalesced_Global_Memory_source
 ```

--- a/Code_Exercises/Coalesced_Global_Memory/solution.cpp
+++ b/Code_Exercises/Coalesced_Global_Memory/solution.cpp
@@ -25,8 +25,8 @@ inline constexpr int filterWidth = 11;
 inline constexpr int halo = filterWidth / 2;
 
 int main() {
-  const char *inputImageFile = "../Images/dogs.png";
-  const char *outputImageFile = "../Images/blurred_dogs.png";
+  const char* inputImageFile = "../Images/dogs.png";
+  const char* outputImageFile = "../Images/blurred_dogs.png";
 
   auto inputImage = util::read_image(inputImageFile, halo);
 
@@ -36,7 +36,7 @@ int main() {
   auto filter = util::generate_filter(util::filter_type::blur, filterWidth);
 
   try {
-    sycl::queue myQueue{sycl::gpu_selector_v};
+    sycl::queue myQueue { sycl::gpu_selector_v };
 
     std::cout << "Running on "
               << myQueue.get_device().get_info<sycl::info::device::name>()
@@ -60,17 +60,17 @@ int main() {
     auto filterRange = filterWidth * sycl::range(1, channels);
 
     {
-      auto inBuf = sycl::buffer{inputImage.data(), inBufRange};
-      auto outBuf = sycl::buffer<float, 2>{outBufRange};
-      auto filterBuf = sycl::buffer{filter.data(), filterRange};
+      auto inBuf = sycl::buffer { inputImage.data(), inBufRange };
+      auto outBuf = sycl::buffer<float, 2> { outBufRange };
+      auto filterBuf = sycl::buffer { filter.data(), filterRange };
       outBuf.set_final_data(outputImage.data());
 
       util::benchmark(
           [&]() {
-            myQueue.submit([&](sycl::handler &cgh) {
-              sycl::accessor inputAcc{inBuf, cgh, sycl::read_only};
-              sycl::accessor outputAcc{outBuf, cgh, sycl::write_only};
-              sycl::accessor filterAcc{filterBuf, cgh, sycl::read_only};
+            myQueue.submit([&](sycl::handler& cgh) {
+              sycl::accessor inputAcc { inBuf, cgh, sycl::read_only };
+              sycl::accessor outputAcc { outBuf, cgh, sycl::write_only };
+              sycl::accessor filterAcc { filterBuf, cgh, sycl::read_only };
 
               cgh.parallel_for<image_convolution>(
                   ndRange, [=](sycl::nd_item<2> item) {
@@ -81,7 +81,7 @@ int main() {
                     auto src = (globalId + haloOffset) * channelsStride;
                     auto dest = globalId * channelsStride;
 
-                    float sum[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+                    float sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
                     for (int r = 0; r < filterWidth; ++r) {
                       for (int c = 0; c < filterWidth; ++c) {
@@ -99,7 +99,7 @@ int main() {
                     }
 
                     for (size_t i = 0; i < 4; ++i) {
-                      outputAcc[dest + sycl::id{0, i}] = sum[i];
+                      outputAcc[dest + sycl::id { 0, i }] = sum[i];
                     }
                   });
             });
@@ -108,7 +108,7 @@ int main() {
           },
           100, "image convolution (coalesced)");
     }
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/Coalesced_Global_Memory/solution.cpp
+++ b/Code_Exercises/Coalesced_Global_Memory/solution.cpp
@@ -8,6 +8,8 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
+
 #include <algorithm>
 #include <iostream>
 
@@ -112,5 +114,5 @@ int main() {
 
   util::write_image(outputImage, outputImageFile);
 
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Coalesced_Global_Memory/solution.cpp
+++ b/Code_Exercises/Coalesced_Global_Memory/solution.cpp
@@ -11,9 +11,6 @@
 #include <algorithm>
 #include <iostream>
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 #include <sycl/sycl.hpp>
 
 #include <benchmark.h>
@@ -25,11 +22,9 @@ inline constexpr util::filter_type filterType = util::filter_type::blur;
 inline constexpr int filterWidth = 11;
 inline constexpr int halo = filterWidth / 2;
 
-TEST_CASE("image_convolution_coalesced", "coalesced_global_memory_solution") {
-  const char* inputImageFile =
-      "../Images/dogs.png";
-  const char* outputImageFile =
-      "../Images/blurred_dogs.png";
+int main() {
+  const char *inputImageFile = "../Images/dogs.png";
+  const char *outputImageFile = "../Images/blurred_dogs.png";
 
   auto inputImage = util::read_image(inputImageFile, halo);
 
@@ -70,7 +65,7 @@ TEST_CASE("image_convolution_coalesced", "coalesced_global_memory_solution") {
 
       util::benchmark(
           [&]() {
-            myQueue.submit([&](sycl::handler& cgh) {
+            myQueue.submit([&](sycl::handler &cgh) {
               sycl::accessor inputAcc{inBuf, cgh, sycl::read_only};
               sycl::accessor outputAcc{outBuf, cgh, sycl::write_only};
               sycl::accessor filterAcc{filterBuf, cgh, sycl::read_only};
@@ -111,11 +106,11 @@ TEST_CASE("image_convolution_coalesced", "coalesced_global_memory_solution") {
           },
           100, "image convolution (coalesced)");
     }
-  } catch (const sycl::exception& e) {
+  } catch (const sycl::exception &e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
   util::write_image(outputImage, outputImageFile);
 
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Coalesced_Global_Memory/source.cpp
+++ b/Code_Exercises/Coalesced_Global_Memory/source.cpp
@@ -8,9 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include <cassert>
+#include "../helpers.hpp"
 
 int main() {
   // Use your code from Exercise 15 to start
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Coalesced_Global_Memory/source.cpp
+++ b/Code_Exercises/Coalesced_Global_Memory/source.cpp
@@ -8,10 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
 
-TEST_CASE("image_convolution_coalesced", "coalesced_global_memory_source") {
+int main() {
   // Use your code from Exercise 15 to start
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Data_Parallelism/solution.cpp
+++ b/Code_Exercises/Data_Parallelism/solution.cpp
@@ -8,14 +8,11 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 #include <sycl/sycl.hpp>
 
 class vector_add;
 
-TEST_CASE("vector_add", "vector_add_solution") {
+int main() {
   constexpr size_t dataSize = 1024;
 
   float a[dataSize], b[dataSize], r[dataSize];
@@ -33,7 +30,7 @@ TEST_CASE("vector_add", "vector_add_solution") {
     auto bufR = sycl::buffer{r, sycl::range{dataSize}};
 
     defaultQueue
-        .submit([&](sycl::handler& cgh) {
+        .submit([&](sycl::handler &cgh) {
           sycl::accessor accA{bufA, cgh, sycl::read_only};
           sycl::accessor accB{bufB, cgh, sycl::read_only};
           sycl::accessor accR{bufR, cgh, sycl::write_only};
@@ -45,11 +42,11 @@ TEST_CASE("vector_add", "vector_add_solution") {
         .wait();
 
     defaultQueue.throw_asynchronous();
-  } catch (const sycl::exception& e) {
+  } catch (const sycl::exception &e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    REQUIRE(r[i] == static_cast<float>(i) * 2.0f);
+    assert(r[i] == static_cast<float>(i) * 2.0f);
   }
 }

--- a/Code_Exercises/Data_Parallelism/solution.cpp
+++ b/Code_Exercises/Data_Parallelism/solution.cpp
@@ -24,26 +24,26 @@ int main() {
   }
 
   try {
-    auto defaultQueue = sycl::queue{};
+    auto defaultQueue = sycl::queue {};
 
-    auto bufA = sycl::buffer{a, sycl::range{dataSize}};
-    auto bufB = sycl::buffer{b, sycl::range{dataSize}};
-    auto bufR = sycl::buffer{r, sycl::range{dataSize}};
+    auto bufA = sycl::buffer { a, sycl::range { dataSize } };
+    auto bufB = sycl::buffer { b, sycl::range { dataSize } };
+    auto bufR = sycl::buffer { r, sycl::range { dataSize } };
 
     defaultQueue
-        .submit([&](sycl::handler &cgh) {
-          sycl::accessor accA{bufA, cgh, sycl::read_only};
-          sycl::accessor accB{bufB, cgh, sycl::read_only};
-          sycl::accessor accR{bufR, cgh, sycl::write_only};
+        .submit([&](sycl::handler& cgh) {
+          sycl::accessor accA { bufA, cgh, sycl::read_only };
+          sycl::accessor accB { bufB, cgh, sycl::read_only };
+          sycl::accessor accR { bufR, cgh, sycl::write_only };
 
           cgh.parallel_for<vector_add>(
-              sycl::range{dataSize},
+              sycl::range { dataSize },
               [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
         })
         .wait();
 
     defaultQueue.throw_asynchronous();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/Data_Parallelism/solution.cpp
+++ b/Code_Exercises/Data_Parallelism/solution.cpp
@@ -8,6 +8,7 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
 #include <sycl/sycl.hpp>
 
 class vector_add;
@@ -47,6 +48,6 @@ int main() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(r[i] == static_cast<float>(i) * 2.0f);
+    SYCLACADEMY_ASSERT(r[i] == static_cast<float>(i) * 2.0f);
   }
 }

--- a/Code_Exercises/Data_Parallelism/source.cpp
+++ b/Code_Exercises/Data_Parallelism/source.cpp
@@ -32,16 +32,17 @@
  *              // Do something
  *          });
  * //    3. Enqueue a parallel for:
- *          cgh.parallel_for<class mykernel>(sycl::range{n}, [=](sycl::id<1> i) {
+ *          cgh.parallel_for<class mykernel>(sycl::range{n}, [=](sycl::id<1> i)
+ {
  *              // Do something
  *          });
  *
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
+#include <cstddef>
 
-TEST_CASE("vector_add", "vector_add_solution") {
+int main() {
   constexpr size_t dataSize = 1024;
 
   float a[dataSize], b[dataSize], r[dataSize];
@@ -57,6 +58,6 @@ TEST_CASE("vector_add", "vector_add_solution") {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    REQUIRE(r[i] == static_cast<float>(i) * 2.0f);
+    assert(r[i] == static_cast<float>(i) * 2.0f);
   }
 }

--- a/Code_Exercises/Data_Parallelism/source.cpp
+++ b/Code_Exercises/Data_Parallelism/source.cpp
@@ -39,8 +39,7 @@
  *
 */
 
-#include <cassert>
-#include <cstddef>
+#include "../helpers.hpp"
 
 int main() {
   constexpr size_t dataSize = 1024;
@@ -58,6 +57,6 @@ int main() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(r[i] == static_cast<float>(i) * 2.0f);
+    SYCLACADEMY_ASSERT(r[i] == static_cast<float>(i) * 2.0f);
   }
 }

--- a/Code_Exercises/Data_and_Dependencies/solution.cpp
+++ b/Code_Exercises/Data_and_Dependencies/solution.cpp
@@ -8,6 +8,8 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
+
 #include <sycl/sycl.hpp>
 
 class kernel_a_1;
@@ -89,7 +91,7 @@ void test_buffer() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(out[i] == i * 2.0f);
+    SYCLACADEMY_ASSERT(out[i] == i * 2.0f);
   }
 }
 
@@ -156,7 +158,7 @@ void test_usm() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(out[i] == i * 2.0f);
+    SYCLACADEMY_ASSERT(out[i] == i * 2.0f);
   }
 }
 

--- a/Code_Exercises/Data_and_Dependencies/solution.cpp
+++ b/Code_Exercises/Data_and_Dependencies/solution.cpp
@@ -21,7 +21,7 @@ class kernel_b_2;
 class kernel_c_2;
 class kernel_d_2;
 
-int usm_selector(const sycl::device &dev) {
+int usm_selector(const sycl::device& dev) {
   if (dev.has(sycl::aspect::usm_device_allocations)) {
     if (dev.has(sycl::aspect::gpu))
       return 2;
@@ -42,51 +42,51 @@ void test_buffer() {
   }
 
   try {
-    auto defaultQueue = sycl::queue{};
+    auto defaultQueue = sycl::queue {};
 
-    auto bufInA = sycl::buffer{inA, sycl::range{dataSize}};
-    auto bufInB = sycl::buffer{inB, sycl::range{dataSize}};
-    auto bufInC = sycl::buffer{inC, sycl::range{dataSize}};
-    auto bufOut = sycl::buffer{out, sycl::range{dataSize}};
+    auto bufInA = sycl::buffer { inA, sycl::range { dataSize } };
+    auto bufInB = sycl::buffer { inB, sycl::range { dataSize } };
+    auto bufInC = sycl::buffer { inC, sycl::range { dataSize } };
+    auto bufOut = sycl::buffer { out, sycl::range { dataSize } };
 
-    defaultQueue.submit([&](sycl::handler &cgh) {
-      sycl::accessor acc{bufInA, cgh, sycl::read_write};
+    defaultQueue.submit([&](sycl::handler& cgh) {
+      sycl::accessor acc { bufInA, cgh, sycl::read_write };
 
-      cgh.parallel_for<kernel_a_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
-        acc[idx] = acc[idx] * 2.0f;
-      });
+      cgh.parallel_for<kernel_a_1>(
+          sycl::range { dataSize },
+          [=](sycl::id<1> idx) { acc[idx] = acc[idx] * 2.0f; });
     });
 
-    defaultQueue.submit([&](sycl::handler &cgh) {
-      sycl::accessor accIn{bufInA, cgh, sycl::read_only};
-      sycl::accessor accOut{bufInB, cgh, sycl::read_write};
+    defaultQueue.submit([&](sycl::handler& cgh) {
+      sycl::accessor accIn { bufInA, cgh, sycl::read_only };
+      sycl::accessor accOut { bufInB, cgh, sycl::read_write };
 
-      cgh.parallel_for<kernel_b_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
-        accOut[idx] += accIn[idx];
-      });
+      cgh.parallel_for<kernel_b_1>(
+          sycl::range { dataSize },
+          [=](sycl::id<1> idx) { accOut[idx] += accIn[idx]; });
     });
 
-    defaultQueue.submit([&](sycl::handler &cgh) {
-      sycl::accessor accIn{bufInA, cgh, sycl::read_only};
-      sycl::accessor accOut{bufInC, cgh, sycl::read_write};
+    defaultQueue.submit([&](sycl::handler& cgh) {
+      sycl::accessor accIn { bufInA, cgh, sycl::read_only };
+      sycl::accessor accOut { bufInC, cgh, sycl::read_write };
 
-      cgh.parallel_for<kernel_c_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
-        accOut[idx] -= accIn[idx];
-      });
+      cgh.parallel_for<kernel_c_1>(
+          sycl::range { dataSize },
+          [=](sycl::id<1> idx) { accOut[idx] -= accIn[idx]; });
     });
 
-    defaultQueue.submit([&](sycl::handler &cgh) {
-      sycl::accessor accInA{bufInB, cgh, sycl::read_only};
-      sycl::accessor accInB{bufInC, cgh, sycl::read_only};
-      sycl::accessor accOut{bufOut, cgh, sycl::write_only};
+    defaultQueue.submit([&](sycl::handler& cgh) {
+      sycl::accessor accInA { bufInB, cgh, sycl::read_only };
+      sycl::accessor accInB { bufInC, cgh, sycl::read_only };
+      sycl::accessor accOut { bufOut, cgh, sycl::write_only };
 
-      cgh.parallel_for<kernel_d_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
-        accOut[idx] = accInA[idx] + accInB[idx];
-      });
+      cgh.parallel_for<kernel_d_1>(
+          sycl::range { dataSize },
+          [=](sycl::id<1> idx) { accOut[idx] = accInA[idx] + accInB[idx]; });
     });
 
     defaultQueue.wait_and_throw();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
@@ -107,7 +107,7 @@ void test_usm() {
   }
 
   try {
-    auto usmQueue = sycl::queue{usm_selector};
+    auto usmQueue = sycl::queue { usm_selector };
 
     auto devicePtrInA = sycl::malloc_device<float>(dataSize, usmQueue);
     auto devicePtrInB = sycl::malloc_device<float>(dataSize, usmQueue);
@@ -119,25 +119,25 @@ void test_usm() {
     auto e3 = usmQueue.memcpy(devicePtrInC, inC, sizeof(float) * dataSize);
 
     auto e4 = usmQueue.parallel_for<kernel_a_2>(
-        sycl::range{dataSize}, e1, [=](sycl::id<1> idx) {
+        sycl::range { dataSize }, e1, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrInA[globalId] = devicePtrInA[globalId] * 2.0f;
         });
 
     auto e5 = usmQueue.parallel_for<kernel_b_2>(
-        sycl::range{dataSize}, {e2, e4}, [=](sycl::id<1> idx) {
+        sycl::range { dataSize }, { e2, e4 }, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrInB[globalId] += devicePtrInA[globalId];
         });
 
     auto e6 = usmQueue.parallel_for<kernel_c_2>(
-        sycl::range{dataSize}, {e3, e4}, [=](sycl::id<1> idx) {
+        sycl::range { dataSize }, { e3, e4 }, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrInC[globalId] -= devicePtrInA[globalId];
         });
 
     auto e7 = usmQueue.parallel_for<kernel_d_2>(
-        sycl::range{dataSize}, {e5, e6}, [=](sycl::id<1> idx) {
+        sycl::range { dataSize }, { e5, e6 }, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrOut[globalId] =
               devicePtrInB[globalId] + devicePtrInC[globalId];
@@ -153,7 +153,7 @@ void test_usm() {
     sycl::free(devicePtrOut, usmQueue);
 
     usmQueue.throw_asynchronous();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/Data_and_Dependencies/source.cpp
+++ b/Code_Exercises/Data_and_Dependencies/source.cpp
@@ -51,8 +51,7 @@
  *
 */
 
-#include <cassert>
-#include <cstddef>
+#include "../helpers.hpp"
 
 int main() {
   constexpr size_t dataSize = 1024;
@@ -89,6 +88,6 @@ int main() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(out[i] == i * 2.0f);
+    SYCLACADEMY_ASSERT(out[i] == i * 2.0f);
   }
 }

--- a/Code_Exercises/Data_and_Dependencies/source.cpp
+++ b/Code_Exercises/Data_and_Dependencies/source.cpp
@@ -51,10 +51,10 @@
  *
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
+#include <cstddef>
 
-TEST_CASE("managing_dependencies", "managing_dependencies_source") {
+int main() {
   constexpr size_t dataSize = 1024;
 
   int inA[dataSize], inB[dataSize], inC[dataSize], out[dataSize];
@@ -89,6 +89,6 @@ TEST_CASE("managing_dependencies", "managing_dependencies_source") {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    REQUIRE(out[i] == i * 2.0f);
+    assert(out[i] == i * 2.0f);
   }
 }

--- a/Code_Exercises/Device_Discovery/solution.cpp
+++ b/Code_Exercises/Device_Discovery/solution.cpp
@@ -8,9 +8,6 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 #include <sycl/sycl.hpp>
 
 class scalar_add;
@@ -37,7 +34,7 @@ auto intel_gpu_selector2 = [](const sycl::device &dev) {
   return -1;
 };
 
-TEST_CASE("intel_gpu_device_selector", "device_selectors_solution") {
+int main() {
   int a = 18, b = 24, r = 0;
 
   try {
@@ -70,5 +67,5 @@ TEST_CASE("intel_gpu_device_selector", "device_selectors_solution") {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  REQUIRE(r == 42);
+  assert(r == 42);
 }

--- a/Code_Exercises/Device_Discovery/solution.cpp
+++ b/Code_Exercises/Device_Discovery/solution.cpp
@@ -8,6 +8,7 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
 #include <sycl/sycl.hpp>
 
 class scalar_add;
@@ -67,5 +68,5 @@ int main() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  assert(r == 42);
+  SYCLACADEMY_ASSERT(r == 42);
 }

--- a/Code_Exercises/Device_Discovery/solution.cpp
+++ b/Code_Exercises/Device_Discovery/solution.cpp
@@ -14,7 +14,7 @@
 class scalar_add;
 
 // Function device selector
-int intel_gpu_selector1(const sycl::device &dev) {
+int intel_gpu_selector1(const sycl::device& dev) {
   if (dev.has(sycl::aspect::gpu)) {
     auto vendorName = dev.get_info<sycl::info::device::vendor>();
     if (vendorName.find("Intel") != std::string::npos) {
@@ -25,7 +25,7 @@ int intel_gpu_selector1(const sycl::device &dev) {
 }
 
 // Lambda device_selector
-auto intel_gpu_selector2 = [](const sycl::device &dev) {
+auto intel_gpu_selector2 = [](const sycl::device& dev) {
   if (dev.has(sycl::aspect::gpu)) {
     auto vendorName = dev.get_info<sycl::info::device::vendor>();
     if (vendorName.find("Intel") != std::string::npos) {
@@ -40,23 +40,23 @@ int main() {
 
   try {
 
-    auto defaultQueue1 = sycl::queue{intel_gpu_selector1};
-    auto defaultQueue2 = sycl::queue{intel_gpu_selector2};
+    auto defaultQueue1 = sycl::queue { intel_gpu_selector1 };
+    auto defaultQueue2 = sycl::queue { intel_gpu_selector2 };
 
     std::cout << "Chosen device: "
               << defaultQueue1.get_device().get_info<sycl::info::device::name>()
               << std::endl;
 
     {
-      auto bufA = sycl::buffer{&a, sycl::range{1}};
-      auto bufB = sycl::buffer{&b, sycl::range{1}};
-      auto bufR = sycl::buffer{&r, sycl::range{1}};
+      auto bufA = sycl::buffer { &a, sycl::range { 1 } };
+      auto bufB = sycl::buffer { &b, sycl::range { 1 } };
+      auto bufR = sycl::buffer { &r, sycl::range { 1 } };
 
       defaultQueue1
-          .submit([&](sycl::handler &cgh) {
-            auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
-            auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
-            auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
+          .submit([&](sycl::handler& cgh) {
+            auto accA = sycl::accessor { bufA, cgh, sycl::read_only };
+            auto accB = sycl::accessor { bufB, cgh, sycl::read_only };
+            auto accR = sycl::accessor { bufR, cgh, sycl::write_only };
 
             cgh.single_task<scalar_add>([=]() { accR[0] = accA[0] + accB[0]; });
           })
@@ -64,7 +64,7 @@ int main() {
     }
 
     defaultQueue1.throw_asynchronous();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/Device_Discovery/source.cpp
+++ b/Code_Exercises/Device_Discovery/source.cpp
@@ -59,18 +59,18 @@ int main() {
 
   try {
     // Task: add a device selector to create this queue with an Intel GPU
-    auto defaultQueue = sycl::queue{};
+    auto defaultQueue = sycl::queue {};
 
     {
-      auto bufA = sycl::buffer{&a, sycl::range{1}};
-      auto bufB = sycl::buffer{&b, sycl::range{1}};
-      auto bufR = sycl::buffer{&r, sycl::range{1}};
+      auto bufA = sycl::buffer { &a, sycl::range { 1 } };
+      auto bufB = sycl::buffer { &b, sycl::range { 1 } };
+      auto bufR = sycl::buffer { &r, sycl::range { 1 } };
 
       defaultQueue
-          .submit([&](sycl::handler &cgh) {
-            auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
-            auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
-            auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
+          .submit([&](sycl::handler& cgh) {
+            auto accA = sycl::accessor { bufA, cgh, sycl::read_only };
+            auto accB = sycl::accessor { bufB, cgh, sycl::read_only };
+            auto accR = sycl::accessor { bufR, cgh, sycl::write_only };
 
             cgh.single_task<scalar_add>([=]() { accR[0] = accA[0] + accB[0]; });
           })
@@ -78,7 +78,7 @@ int main() {
     }
 
     defaultQueue.throw_asynchronous();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/Device_Discovery/source.cpp
+++ b/Code_Exercises/Device_Discovery/source.cpp
@@ -43,20 +43,17 @@
  * // Query a device for some things:
  * std::string vendor = dev.get_info<sycl::info::device::vendor>();
  * std::string dev_name = dev.get_info<sycl::info::device::name>();
- * std::string dev_driver_ver = dev.get_info<sycl::info::device::driver_version>();
+ * std::string dev_driver_ver =
+ dev.get_info<sycl::info::device::driver_version>();
  *
  *
 */
-
-
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
 
 #include <sycl/sycl.hpp>
 
 class scalar_add;
 
-TEST_CASE("intel_gpu_device_selector", "device_selectors_solution") {
+int main() {
   int a = 18, b = 24, r = 0;
 
   try {
@@ -69,7 +66,7 @@ TEST_CASE("intel_gpu_device_selector", "device_selectors_solution") {
       auto bufR = sycl::buffer{&r, sycl::range{1}};
 
       defaultQueue
-          .submit([&](sycl::handler& cgh) {
+          .submit([&](sycl::handler &cgh) {
             auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
             auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
             auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
@@ -80,9 +77,9 @@ TEST_CASE("intel_gpu_device_selector", "device_selectors_solution") {
     }
 
     defaultQueue.throw_asynchronous();
-  } catch (const sycl::exception& e) {
+  } catch (const sycl::exception &e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  REQUIRE(r == 42);
+  assert(r == 42);
 }

--- a/Code_Exercises/Device_Discovery/source.cpp
+++ b/Code_Exercises/Device_Discovery/source.cpp
@@ -49,6 +49,7 @@
  *
 */
 
+#include "../helpers.hpp"
 #include <sycl/sycl.hpp>
 
 class scalar_add;
@@ -81,5 +82,5 @@ int main() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  assert(r == 42);
+  SYCLACADEMY_ASSERT(r == 42);
 }

--- a/Code_Exercises/Enqueueing_a_Kernel/solution.cpp
+++ b/Code_Exercises/Enqueueing_a_Kernel/solution.cpp
@@ -8,6 +8,7 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
 #include <sycl/sycl.hpp>
 
 class hello_world;
@@ -23,5 +24,5 @@ int main() {
       })
       .wait();
 
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Enqueueing_a_Kernel/solution.cpp
+++ b/Code_Exercises/Enqueueing_a_Kernel/solution.cpp
@@ -8,23 +8,20 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 #include <sycl/sycl.hpp>
 
 class hello_world;
 
-TEST_CASE("hello_world", "hello_world_solution") {
+int main() {
   auto defaultQueue = sycl::queue{};
 
   defaultQueue
-      .submit([&](sycl::handler& cgh) {
+      .submit([&](sycl::handler &cgh) {
         auto os = sycl::stream{128, 128, cgh};
 
         cgh.single_task<hello_world>([=]() { os << "Hello World!\n"; });
       })
       .wait();
 
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Enqueueing_a_Kernel/solution.cpp
+++ b/Code_Exercises/Enqueueing_a_Kernel/solution.cpp
@@ -14,11 +14,11 @@
 class hello_world;
 
 int main() {
-  auto defaultQueue = sycl::queue{};
+  auto defaultQueue = sycl::queue {};
 
   defaultQueue
-      .submit([&](sycl::handler &cgh) {
-        auto os = sycl::stream{128, 128, cgh};
+      .submit([&](sycl::handler& cgh) {
+        auto os = sycl::stream { 128, 128, cgh };
 
         cgh.single_task<hello_world>([=]() { os << "Hello World!\n"; });
       })

--- a/Code_Exercises/Enqueueing_a_Kernel/source.cpp
+++ b/Code_Exercises/Enqueueing_a_Kernel/source.cpp
@@ -34,7 +34,7 @@
  *
  */
 
-#include <cassert>
+#include "../helpers.hpp"
 #include <iostream>
 
 int main() {
@@ -44,5 +44,5 @@ int main() {
 
   // Task: Have this message print from the SYCL device instead of the host
 
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Enqueueing_a_Kernel/source.cpp
+++ b/Code_Exercises/Enqueueing_a_Kernel/source.cpp
@@ -34,15 +34,15 @@
  *
  */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
+#include <iostream>
 
-TEST_CASE("hello_world", "hello_world_source") {
+int main() {
 
   // Print "Hello World!\n"
   std::cout << "Hello World!\n";
 
   // Task: Have this message print from the SYCL device instead of the host
 
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Functors/solution.cpp
+++ b/Code_Exercises/Functors/solution.cpp
@@ -8,6 +8,8 @@
    work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
  */
 
+#include "../helpers.hpp"
+
 #include <algorithm>
 #include <iostream>
 
@@ -207,5 +209,5 @@ int main() {
 
   util::write_image(outputImage, outputImageFile);
 
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Functors/solution.cpp
+++ b/Code_Exercises/Functors/solution.cpp
@@ -56,7 +56,7 @@ public:
                                  const Direction &dir)
       : inputAcc_{in, cgh, sycl::read_only}, outputAcc_{out, cgh,
                                                         sycl::write_only},
-        filterAcc_{filterType, cgh, sycl::write_only}, dir_(dir) {
+        filterAcc_{filter, cgh, sycl::read_only}, dir_(dir) {
     filterWidth_ = filterAcc_.size();
     halo_ = filterWidth_ / 2;
   }

--- a/Code_Exercises/Functors/solution.cpp
+++ b/Code_Exercises/Functors/solution.cpp
@@ -11,9 +11,6 @@
 #include <algorithm>
 #include <iostream>
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 #include <sycl/sycl.hpp>
 
 #include <benchmark.h>
@@ -135,7 +132,7 @@ inline constexpr util::filter_type filterType = util::filter_type::blur;
 inline constexpr int filterWidth = 11;
 inline constexpr int halo = filterWidth / 2;
 
-TEST_CASE("image_convolution_1D", "1D_solution") {
+int main() {
   const char *inputImageFile = "../Images/dogs.png";
   const char *outputImageFile = "../Images/blurred_dogs_1D.png";
 
@@ -210,5 +207,5 @@ TEST_CASE("image_convolution_1D", "1D_solution") {
 
   util::write_image(outputImage, outputImageFile);
 
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Functors/source.cpp
+++ b/Code_Exercises/Functors/source.cpp
@@ -8,10 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
 
-TEST_CASE("image_convolution_1D", "1_source") {
+int main() {
   // Use your code from Exercise Vectors to start
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Functors/source.cpp
+++ b/Code_Exercises/Functors/source.cpp
@@ -8,9 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include <cassert>
+#include "../helpers.hpp"
 
 int main() {
   // Use your code from Exercise Vectors to start
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Handling_Errors/solution.cpp
+++ b/Code_Exercises/Handling_Errors/solution.cpp
@@ -8,6 +8,8 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
+
 #include <sycl/sycl.hpp>
 
 int main() {
@@ -32,5 +34,5 @@ int main() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Handling_Errors/solution.cpp
+++ b/Code_Exercises/Handling_Errors/solution.cpp
@@ -15,22 +15,22 @@
 int main() {
   try {
     auto asyncHandler = [&](sycl::exception_list exceptionList) {
-      for (auto &e : exceptionList) {
+      for (auto& e : exceptionList) {
         std::rethrow_exception(e);
       }
     };
 
-    auto defaultQueue = sycl::queue{asyncHandler};
+    auto defaultQueue = sycl::queue { asyncHandler };
 
-    auto buf = sycl::buffer<int>(sycl::range{1});
+    auto buf = sycl::buffer<int>(sycl::range { 1 });
 
-    defaultQueue.submit([&](sycl::handler &cgh) {
+    defaultQueue.submit([&](sycl::handler& cgh) {
       // This throws an exception: an accessor has a range which is
       // outside the bounds of its buffer.
-      auto acc = buf.get_access(cgh, sycl::range{2}, sycl::read_write);
+      auto acc = buf.get_access(cgh, sycl::range { 2 }, sycl::read_write);
     });
     defaultQueue.wait_and_throw();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/Handling_Errors/solution.cpp
+++ b/Code_Exercises/Handling_Errors/solution.cpp
@@ -8,15 +8,12 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 #include <sycl/sycl.hpp>
 
-TEST_CASE("handling_errors", "handling_errors_source") {
+int main() {
   try {
     auto asyncHandler = [&](sycl::exception_list exceptionList) {
-      for (auto& e : exceptionList) {
+      for (auto &e : exceptionList) {
         std::rethrow_exception(e);
       }
     };
@@ -25,15 +22,15 @@ TEST_CASE("handling_errors", "handling_errors_source") {
 
     auto buf = sycl::buffer<int>(sycl::range{1});
 
-    defaultQueue.submit([&](sycl::handler& cgh) {
+    defaultQueue.submit([&](sycl::handler &cgh) {
       // This throws an exception: an accessor has a range which is
       // outside the bounds of its buffer.
       auto acc = buf.get_access(cgh, sycl::range{2}, sycl::read_write);
     });
     defaultQueue.wait_and_throw();
-  } catch (const sycl::exception& e) {
+  } catch (const sycl::exception &e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Handling_Errors/source.cpp
+++ b/Code_Exercises/Handling_Errors/source.cpp
@@ -8,6 +8,7 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
 
 #include <sycl/sycl.hpp>
 
@@ -27,5 +28,5 @@ int main() {
 
   defaultQueue.throw_asynchronous();
 
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Handling_Errors/source.cpp
+++ b/Code_Exercises/Handling_Errors/source.cpp
@@ -16,15 +16,17 @@ int main() {
 
   // Task: catch synchronous and asynchronous exceptions
 
-  auto defaultQueue = sycl::queue{};
+  auto defaultQueue = sycl::queue {};
 
-  auto buf = sycl::buffer<int>(sycl::range{1});
+  auto buf = sycl::buffer<int>(sycl::range { 1 });
 
-  defaultQueue.submit([&](sycl::handler& cgh) {
-    // This throws an exception: an accessor has a range which is
-    // outside the bounds of its buffer.
-    auto acc = buf.get_access(cgh, sycl::range{2}, sycl::read_write);
-  }).wait();
+  defaultQueue
+      .submit([&](sycl::handler& cgh) {
+        // This throws an exception: an accessor has a range which is
+        // outside the bounds of its buffer.
+        auto acc = buf.get_access(cgh, sycl::range { 2 }, sycl::read_write);
+      })
+      .wait();
 
   defaultQueue.throw_asynchronous();
 

--- a/Code_Exercises/Handling_Errors/source.cpp
+++ b/Code_Exercises/Handling_Errors/source.cpp
@@ -8,12 +8,10 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
 
 #include <sycl/sycl.hpp>
 
-TEST_CASE("handling_errors", "handling_errors_source") {
+int main() {
 
   // Task: catch synchronous and asynchronous exceptions
 
@@ -29,5 +27,5 @@ TEST_CASE("handling_errors", "handling_errors_source") {
 
   defaultQueue.throw_asynchronous();
 
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Image_Convolution/reference.cpp
+++ b/Code_Exercises/Image_Convolution/reference.cpp
@@ -11,9 +11,6 @@
 #include <algorithm>
 #include <iostream>
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 #include <benchmark.h>
 #include <image_conv.h>
 
@@ -25,11 +22,9 @@ inline constexpr util::filter_type filterType = util::filter_type::blur;
 inline constexpr int filterWidth = 11;
 inline constexpr int halo = filterWidth / 2;
 
-TEST_CASE("image_convolution_naive", "image_convolution_reference") {
-  const char* inputImageFile =
-      "../Images/dogs.png";
-  const char* outputImageFile =
-      "../Images/blurred_dogs.png";
+int main() {
+  const char *inputImageFile = "../Images/dogs.png";
+  const char *outputImageFile = "../Images/blurred_dogs.png";
 
   auto inputImage = util::read_image(inputImageFile, halo);
 
@@ -61,7 +56,6 @@ TEST_CASE("image_convolution_naive", "image_convolution_reference") {
     auto outBufRange =
         sycl::range(inputImgHeight, inputImgWidth) * sycl::range(1, channels);
 
-
     auto filterRange = filterWidth * sycl::range(1, channels);
 
     {
@@ -72,7 +66,7 @@ TEST_CASE("image_convolution_naive", "image_convolution_reference") {
 
       util::benchmark(
           [&]() {
-            myQueue.submit([&](sycl::handler& cgh) {
+            myQueue.submit([&](sycl::handler &cgh) {
               sycl::accessor inputAcc{inBuf, cgh, sycl::read_only};
               sycl::accessor outputAcc{outBuf, cgh, sycl::write_only};
               sycl::accessor filterAcc{filterBuf, cgh, sycl::read_only};
@@ -114,11 +108,11 @@ TEST_CASE("image_convolution_naive", "image_convolution_reference") {
           },
           100, "image convolution (coalesced)");
     }
-  } catch (const sycl::exception& e) {
+  } catch (const sycl::exception &e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
   util::write_image(outputImage, outputImageFile);
 
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Image_Convolution/reference.cpp
+++ b/Code_Exercises/Image_Convolution/reference.cpp
@@ -8,6 +8,8 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
+
 #include <algorithm>
 #include <iostream>
 
@@ -114,5 +116,5 @@ int main() {
 
   util::write_image(outputImage, outputImageFile);
 
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Image_Convolution/reference.cpp
+++ b/Code_Exercises/Image_Convolution/reference.cpp
@@ -25,8 +25,8 @@ inline constexpr int filterWidth = 11;
 inline constexpr int halo = filterWidth / 2;
 
 int main() {
-  const char *inputImageFile = "../Images/dogs.png";
-  const char *outputImageFile = "../Images/blurred_dogs.png";
+  const char* inputImageFile = "../Images/dogs.png";
+  const char* outputImageFile = "../Images/blurred_dogs.png";
 
   auto inputImage = util::read_image(inputImageFile, halo);
 
@@ -36,7 +36,7 @@ int main() {
   auto filter = util::generate_filter(util::filter_type::blur, filterWidth);
 
   try {
-    sycl::queue myQueue{sycl::gpu_selector_v};
+    sycl::queue myQueue { sycl::gpu_selector_v };
 
     std::cout << "Running on "
               << myQueue.get_device().get_info<sycl::info::device::name>()
@@ -61,29 +61,29 @@ int main() {
     auto filterRange = filterWidth * sycl::range(1, channels);
 
     {
-      auto inBuf = sycl::buffer{inputImage.data(), inBufRange};
-      auto outBuf = sycl::buffer<float, 2>{outBufRange};
-      auto filterBuf = sycl::buffer{filter.data(), filterRange};
+      auto inBuf = sycl::buffer { inputImage.data(), inBufRange };
+      auto outBuf = sycl::buffer<float, 2> { outBufRange };
+      auto filterBuf = sycl::buffer { filter.data(), filterRange };
       outBuf.set_final_data(outputImage.data());
 
       util::benchmark(
           [&]() {
-            myQueue.submit([&](sycl::handler &cgh) {
-              sycl::accessor inputAcc{inBuf, cgh, sycl::read_only};
-              sycl::accessor outputAcc{outBuf, cgh, sycl::write_only};
-              sycl::accessor filterAcc{filterBuf, cgh, sycl::read_only};
+            myQueue.submit([&](sycl::handler& cgh) {
+              sycl::accessor inputAcc { inBuf, cgh, sycl::read_only };
+              sycl::accessor outputAcc { outBuf, cgh, sycl::write_only };
+              sycl::accessor filterAcc { filterBuf, cgh, sycl::read_only };
 
               cgh.parallel_for<image_convolution>(
                   ndRange, [=](sycl::nd_item<2> item) {
                     auto globalId = item.get_global_id();
-                    globalId = sycl::id{globalId[1], globalId[0]};
+                    globalId = sycl::id { globalId[1], globalId[0] };
 
                     auto channelsStride = sycl::range(1, channels);
                     auto haloOffset = sycl::id(halo, halo);
                     auto src = (globalId + haloOffset) * channelsStride;
                     auto dest = globalId * channelsStride;
 
-                    float sum[4] = {0.0f, 0.0f, 0.0f, 0.0f};
+                    float sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
 
                     for (int r = 0; r < filterWidth; ++r) {
                       for (int c = 0; c < filterWidth; ++c) {
@@ -101,7 +101,7 @@ int main() {
                     }
 
                     for (size_t i = 0; i < 4; ++i) {
-                      outputAcc[dest + sycl::id{0, i}] = sum[i];
+                      outputAcc[dest + sycl::id { 0, i }] = sum[i];
                     }
                   });
             });
@@ -110,7 +110,7 @@ int main() {
           },
           100, "image convolution (coalesced)");
     }
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/In_Order_Queue/queue_benchmarking_helpers.hpp
+++ b/Code_Exercises/In_Order_Queue/queue_benchmarking_helpers.hpp
@@ -35,4 +35,3 @@ template <class T> static T busy_sleep(size_t N, T i) {
   }
   return y;
 }
-

--- a/Code_Exercises/In_Order_Queue/solution_queue_benchmarking.cpp
+++ b/Code_Exercises/In_Order_Queue/solution_queue_benchmarking.cpp
@@ -22,8 +22,6 @@
 // work done by `numIters` `single_task`s here would be better encapsulated in
 // a single `parallel_for` launch with range `numIters`.
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
 #include <sycl/sycl.hpp>
 
 #include "queue_benchmarking_helpers.hpp"
@@ -79,17 +77,17 @@ void run_single_queue(sycl::queue q) {
             << std::endl;
 }
 
-TEST_CASE("in_order_slow", "in_order_queue") {
+void test_in_order_slow() {
   sycl::queue q{sycl::property::queue::in_order{}};
   run_single_queue(q);
 }
 
-TEST_CASE("out_of_order", "in_order_queue") {
+void test_out_of_order() {
   sycl::queue q;
   run_single_queue(q);
 }
 
-TEST_CASE("multiple_in_order_queues", "in_order_queue") {
+void test_multiple_in_order_queues() {
 
   constexpr int numKernelsPerQueue = 10;
   constexpr int numQueues = numIters / numKernelsPerQueue;
@@ -104,9 +102,15 @@ TEST_CASE("multiple_in_order_queues", "in_order_queue") {
   auto singleKernelTime = bench<T>({qs[0]}, 1);
   auto nKernelsTime = bench_multiple_queues<T>(qs, numQueues);
   std::cout << "1 kernel took: " << singleKernelTime << "ms" << std::endl;
-  std::cout << numIters << " in-order kernels took: " << nKernelsTime
-            << "ms" << std::endl;
+  std::cout << numIters << " in-order kernels took: " << nKernelsTime << "ms"
+            << std::endl;
   std::cout << "Ratio N/1: "
             << static_cast<float>(nKernelsTime) / singleKernelTime << std::endl
             << std::endl;
+}
+
+int main() {
+  test_in_order_slow();
+  test_out_of_order();
+  test_multiple_in_order_queues();
 }

--- a/Code_Exercises/In_Order_Queue/solution_queue_benchmarking.cpp
+++ b/Code_Exercises/In_Order_Queue/solution_queue_benchmarking.cpp
@@ -22,6 +22,8 @@
 // work done by `numIters` `single_task`s here would be better encapsulated in
 // a single `parallel_for` launch with range `numIters`.
 
+#include "../helpers.hpp"
+
 #include <sycl/sycl.hpp>
 
 #include "queue_benchmarking_helpers.hpp"

--- a/Code_Exercises/In_Order_Queue/solution_queue_benchmarking.cpp
+++ b/Code_Exercises/In_Order_Queue/solution_queue_benchmarking.cpp
@@ -34,7 +34,7 @@ constexpr int numIters = 100;
 
 // Run busy_sleep numKernels times on a single thread using single_task
 template <typename T> auto bench(sycl::queue q, int numKernels) {
-  auto *out = sycl::malloc_device<T>(numKernels, q);
+  auto* out = sycl::malloc_device<T>(numKernels, q);
 
   auto s = std::chrono::high_resolution_clock::now();
   for (int i = 0; i < numKernels; i++) {
@@ -51,7 +51,7 @@ template <typename T>
 auto bench_multiple_queues(std::vector<sycl::queue> qs,
                            int numKernelsPerQueue) {
 
-  auto *out = sycl::malloc_device<T>(numKernelsPerQueue * qs.size(), qs[0]);
+  auto* out = sycl::malloc_device<T>(numKernelsPerQueue * qs.size(), qs[0]);
 
   auto s = std::chrono::high_resolution_clock::now();
   for (int i = 0; i < numKernelsPerQueue; i++) {
@@ -80,7 +80,7 @@ void run_single_queue(sycl::queue q) {
 }
 
 void test_in_order_slow() {
-  sycl::queue q{sycl::property::queue::in_order{}};
+  sycl::queue q { sycl::property::queue::in_order {} };
   run_single_queue(q);
 }
 
@@ -96,12 +96,12 @@ void test_multiple_in_order_queues() {
 
   std::vector<sycl::queue> qs;
   for (int i = 0; i < numQueues; i++) {
-    sycl::queue q{sycl::property::queue::in_order{}};
+    sycl::queue q { sycl::property::queue::in_order {} };
     qs.push_back(q);
   }
-  bench_multiple_queues<T>({qs[0]}, 1); // Warmup
+  bench_multiple_queues<T>({ qs[0] }, 1); // Warmup
 
-  auto singleKernelTime = bench<T>({qs[0]}, 1);
+  auto singleKernelTime = bench<T>({ qs[0] }, 1);
   auto nKernelsTime = bench_multiple_queues<T>(qs, numQueues);
   std::cout << "1 kernel took: " << singleKernelTime << "ms" << std::endl;
   std::cout << numIters << " in-order kernels took: " << nKernelsTime << "ms"

--- a/Code_Exercises/In_Order_Queue/solution_vector_add.cpp
+++ b/Code_Exercises/In_Order_Queue/solution_vector_add.cpp
@@ -21,7 +21,7 @@ class kernel_b_2;
 class kernel_c_2;
 class kernel_d_2;
 
-int usm_selector(const sycl::device &dev) {
+int usm_selector(const sycl::device& dev) {
   if (dev.has(sycl::aspect::usm_device_allocations)) {
     if (dev.has(sycl::aspect::gpu))
       return 2;
@@ -42,51 +42,52 @@ void test_buffer() {
   }
 
   try {
-    auto inOrderQueue =
-        sycl::queue{sycl::gpu_selector_v, {sycl::property::queue::in_order{}}};
+    auto inOrderQueue = sycl::queue { sycl::gpu_selector_v,
+                                      { sycl::property::queue::in_order {} } };
 
-    auto bufInA = sycl::buffer{inA, sycl::range{dataSize}};
-    auto bufInB = sycl::buffer{inB, sycl::range{dataSize}};
-    auto bufInC = sycl::buffer{inC, sycl::range{dataSize}};
-    auto bufOut = sycl::buffer{out, sycl::range{dataSize}};
+    auto bufInA = sycl::buffer { inA, sycl::range { dataSize } };
+    auto bufInB = sycl::buffer { inB, sycl::range { dataSize } };
+    auto bufInC = sycl::buffer { inC, sycl::range { dataSize } };
+    auto bufOut = sycl::buffer { out, sycl::range { dataSize } };
 
-    inOrderQueue.submit([&](sycl::handler &cgh) {
-      sycl::accessor accInA{bufInA, cgh, sycl::read_write};
+    inOrderQueue.submit([&](sycl::handler& cgh) {
+      sycl::accessor accInA { bufInA, cgh, sycl::read_write };
 
       cgh.parallel_for<kernel_a_1>(
-          sycl::range{dataSize}, [=](sycl::id<1> idx) { accInA[idx] *= 2.0f; });
+          sycl::range { dataSize },
+          [=](sycl::id<1> idx) { accInA[idx] *= 2.0f; });
     });
 
-    inOrderQueue.submit([&](sycl::handler &cgh) {
-      sycl::accessor accIn{bufInA, cgh, sycl::read_only};
-      sycl::accessor accOut{bufInB, cgh, sycl::read_write};
+    inOrderQueue.submit([&](sycl::handler& cgh) {
+      sycl::accessor accIn { bufInA, cgh, sycl::read_only };
+      sycl::accessor accOut { bufInB, cgh, sycl::read_write };
 
-      cgh.parallel_for<kernel_b_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
-        accOut[idx] += accIn[idx];
-      });
+      cgh.parallel_for<kernel_b_1>(
+          sycl::range { dataSize },
+          [=](sycl::id<1> idx) { accOut[idx] += accIn[idx]; });
     });
 
-    inOrderQueue.submit([&](sycl::handler &cgh) {
-      sycl::accessor accInA{bufInA, cgh, sycl::read_only};
-      sycl::accessor accInC{bufInC, cgh, sycl::read_write};
+    inOrderQueue.submit([&](sycl::handler& cgh) {
+      sycl::accessor accInA { bufInA, cgh, sycl::read_only };
+      sycl::accessor accInC { bufInC, cgh, sycl::read_write };
 
-      cgh.parallel_for<kernel_c_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
-        accInC[idx] -= accInA[idx];
-      });
+      cgh.parallel_for<kernel_c_1>(
+          sycl::range { dataSize },
+          [=](sycl::id<1> idx) { accInC[idx] -= accInA[idx]; });
     });
 
-    inOrderQueue.submit([&](sycl::handler &cgh) {
-      sycl::accessor accInB{bufInB, cgh, sycl::read_only};
-      sycl::accessor accInC{bufInC, cgh, sycl::read_only};
-      sycl::accessor accOut{bufOut, cgh, sycl::write_only};
+    inOrderQueue.submit([&](sycl::handler& cgh) {
+      sycl::accessor accInB { bufInB, cgh, sycl::read_only };
+      sycl::accessor accInC { bufInC, cgh, sycl::read_only };
+      sycl::accessor accOut { bufOut, cgh, sycl::write_only };
 
-      cgh.parallel_for<kernel_d_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
-        accOut[idx] = accInB[idx] + accInC[idx];
-      });
+      cgh.parallel_for<kernel_d_1>(
+          sycl::range { dataSize },
+          [=](sycl::id<1> idx) { accOut[idx] = accInB[idx] + accInC[idx]; });
     });
 
     inOrderQueue.wait_and_throw();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
@@ -108,7 +109,7 @@ void test_usm() {
 
   try {
     auto inOrderQueue =
-        sycl::queue{usm_selector, {sycl::property::queue::in_order{}}};
+        sycl::queue { usm_selector, { sycl::property::queue::in_order {} } };
 
     auto devicePtrInA = sycl::malloc_device<float>(dataSize, inOrderQueue);
     auto devicePtrInB = sycl::malloc_device<float>(dataSize, inOrderQueue);
@@ -121,25 +122,25 @@ void test_usm() {
     inOrderQueue.memcpy(devicePtrOut, out, sizeof(float) * dataSize);
 
     inOrderQueue.parallel_for<kernel_a_2>(
-        sycl::range{dataSize}, [=](sycl::id<1> idx) {
+        sycl::range { dataSize }, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrInA[globalId] = devicePtrInA[globalId] * 2.0f;
         });
 
     inOrderQueue.parallel_for<kernel_b_2>(
-        sycl::range{dataSize}, [=](sycl::id<1> idx) {
+        sycl::range { dataSize }, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrInB[globalId] += devicePtrInA[globalId];
         });
 
     inOrderQueue.parallel_for<kernel_c_2>(
-        sycl::range{dataSize}, [=](sycl::id<1> idx) {
+        sycl::range { dataSize }, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrInC[globalId] -= devicePtrInA[globalId];
         });
 
     inOrderQueue.parallel_for<kernel_d_2>(
-        sycl::range{dataSize}, [=](sycl::id<1> idx) {
+        sycl::range { dataSize }, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrOut[globalId] =
               devicePtrInB[globalId] + devicePtrInC[globalId];
@@ -157,7 +158,7 @@ void test_usm() {
     sycl::free(devicePtrInC, inOrderQueue);
     sycl::free(devicePtrOut, inOrderQueue);
 
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/In_Order_Queue/solution_vector_add.cpp
+++ b/Code_Exercises/In_Order_Queue/solution_vector_add.cpp
@@ -8,7 +8,7 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-//#define SYCL_ACADEMY_USING_COMPUTECPP
+#include "../helpers.hpp"
 
 #include <sycl/sycl.hpp>
 
@@ -91,7 +91,7 @@ void test_buffer() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(out[i] == i * 2.0f);
+    SYCLACADEMY_ASSERT(out[i] == i * 2.0f);
   }
 }
 
@@ -162,7 +162,7 @@ void test_usm() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(out[i] == i * 2.0f);
+    SYCLACADEMY_ASSERT(out[i] == i * 2.0f);
   }
 }
 

--- a/Code_Exercises/In_Order_Queue/source_queue_benchmarking.cpp
+++ b/Code_Exercises/In_Order_Queue/source_queue_benchmarking.cpp
@@ -34,7 +34,7 @@ constexpr int numIters = 100;
 
 // Run busy_sleep numKernels times on a single thread using single_task
 template <typename T> auto bench(sycl::queue q, int numKernels) {
-  auto *out = sycl::malloc_device<T>(numKernels, q);
+  auto* out = sycl::malloc_device<T>(numKernels, q);
 
   auto s = std::chrono::high_resolution_clock::now();
   for (int i = 0; i < numKernels; i++) {
@@ -46,7 +46,7 @@ template <typename T> auto bench(sycl::queue q, int numKernels) {
 }
 
 void test_in_order_slow() {
-  sycl::queue q{sycl::property::queue::in_order{}};
+  sycl::queue q { sycl::property::queue::in_order {} };
   bench<T>(q, 1); // Warmup
 
   auto singleKernelTime = bench<T>(q, 1);
@@ -59,6 +59,4 @@ void test_in_order_slow() {
             << std::endl;
 }
 
-int main() {
-  test_in_order_slow();
-}
+int main() { test_in_order_slow(); }

--- a/Code_Exercises/In_Order_Queue/source_queue_benchmarking.cpp
+++ b/Code_Exercises/In_Order_Queue/source_queue_benchmarking.cpp
@@ -22,8 +22,6 @@
 // work done by `numIters` `single_task`s here would be better encapsulated in
 // a single `parallel_for` launch with range `numIters`.
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
 #include <sycl/sycl.hpp>
 
 #include "queue_benchmarking_helpers.hpp"
@@ -45,7 +43,7 @@ template <typename T> auto bench(sycl::queue q, int numKernels) {
   return std::chrono::duration_cast<std::chrono::microseconds>(e - s).count();
 }
 
-TEST_CASE("in_order_slow", "in_order_queue") {
+void test_in_order_slow() {
   sycl::queue q{sycl::property::queue::in_order{}};
   bench<T>(q, 1); // Warmup
 
@@ -57,4 +55,8 @@ TEST_CASE("in_order_slow", "in_order_queue") {
   std::cout << "Ratio N/1: "
             << static_cast<float>(nKernelsTime) / singleKernelTime << std::endl
             << std::endl;
+}
+
+int main() {
+  test_in_order_slow();
 }

--- a/Code_Exercises/In_Order_Queue/source_queue_benchmarking.cpp
+++ b/Code_Exercises/In_Order_Queue/source_queue_benchmarking.cpp
@@ -22,6 +22,8 @@
 // work done by `numIters` `single_task`s here would be better encapsulated in
 // a single `parallel_for` launch with range `numIters`.
 
+#include "../helpers.hpp"
+
 #include <sycl/sycl.hpp>
 
 #include "queue_benchmarking_helpers.hpp"

--- a/Code_Exercises/In_Order_Queue/source_vector_add.cpp
+++ b/Code_Exercises/In_Order_Queue/source_vector_add.cpp
@@ -55,10 +55,9 @@
 
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
 
-TEST_CASE("in_order_queue", "in_order_queue_source") {
+int main() {
   // Use the Exercise 10 solution to start
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/In_Order_Queue/source_vector_add.cpp
+++ b/Code_Exercises/In_Order_Queue/source_vector_add.cpp
@@ -55,9 +55,9 @@
 
 */
 
-#include <cassert>
+#include "../helpers.hpp"
 
 int main() {
   // Use the Exercise 10 solution to start
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Introduction_to_USM/solution.cpp
+++ b/Code_Exercises/Introduction_to_USM/solution.cpp
@@ -8,6 +8,8 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
+
 #include <sycl/sycl.hpp>
 
 int usm_selector(const sycl::device &dev) {
@@ -26,5 +28,5 @@ int main() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Introduction_to_USM/solution.cpp
+++ b/Code_Exercises/Introduction_to_USM/solution.cpp
@@ -8,26 +8,23 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 #include <sycl/sycl.hpp>
 
-int usm_selector(const sycl::device& dev) {
+int usm_selector(const sycl::device &dev) {
   if (dev.has(sycl::aspect::usm_device_allocations)) {
     return 1;
   }
   return -1;
 }
 
-TEST_CASE("usm_selector", "usm_selector_solution") {
+int main() {
   try {
     auto usmQueue = sycl::queue{usm_selector};
 
     usmQueue.throw_asynchronous();
-  } catch (const sycl::exception& e) {
+  } catch (const sycl::exception &e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Introduction_to_USM/solution.cpp
+++ b/Code_Exercises/Introduction_to_USM/solution.cpp
@@ -12,7 +12,7 @@
 
 #include <sycl/sycl.hpp>
 
-int usm_selector(const sycl::device &dev) {
+int usm_selector(const sycl::device& dev) {
   if (dev.has(sycl::aspect::usm_device_allocations)) {
     return 1;
   }
@@ -21,10 +21,10 @@ int usm_selector(const sycl::device &dev) {
 
 int main() {
   try {
-    auto usmQueue = sycl::queue{usm_selector};
+    auto usmQueue = sycl::queue { usm_selector };
 
     usmQueue.throw_asynchronous();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/Introduction_to_USM/source.cpp
+++ b/Code_Exercises/Introduction_to_USM/source.cpp
@@ -8,6 +8,8 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
+
 #include <sycl/sycl.hpp>
 
 int main() {
@@ -16,5 +18,5 @@ int main() {
   // Remember to check for exceptions
   auto usmQueue = sycl::queue{};
 
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Introduction_to_USM/source.cpp
+++ b/Code_Exercises/Introduction_to_USM/source.cpp
@@ -16,7 +16,7 @@ int main() {
 
   // Task: create a queue to a device which supports USM allocations
   // Remember to check for exceptions
-  auto usmQueue = sycl::queue{};
+  auto usmQueue = sycl::queue {};
 
   SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Introduction_to_USM/source.cpp
+++ b/Code_Exercises/Introduction_to_USM/source.cpp
@@ -8,16 +8,13 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 #include <sycl/sycl.hpp>
 
-TEST_CASE("usm_selector", "usm_selector_source") {
+int main() {
 
   // Task: create a queue to a device which supports USM allocations
   // Remember to check for exceptions
-  auto usmQueue  = sycl::queue{};
+  auto usmQueue = sycl::queue{};
 
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Local_Memory_Tiling/solution.cpp
+++ b/Code_Exercises/Local_Memory_Tiling/solution.cpp
@@ -36,7 +36,7 @@ int main() {
   auto filter = util::generate_filter(util::filter_type::blur, filterWidth);
 
   try {
-    sycl::queue myQueue{sycl::gpu_selector_v};
+    sycl::queue myQueue { sycl::gpu_selector_v };
 
     std::cout << "Running on "
               << myQueue.get_device().get_info<sycl::info::device::name>()
@@ -61,9 +61,9 @@ int main() {
     auto scratchpadRange = localRange + sycl::range(halo * 2, halo * 2);
 
     {
-      auto inBuf = sycl::buffer{inputImage.data(), inBufRange};
-      auto outBuf = sycl::buffer<float, 2>{outBufRange};
-      auto filterBuf = sycl::buffer{filter.data(), filterRange};
+      auto inBuf = sycl::buffer { inputImage.data(), inBufRange };
+      auto outBuf = sycl::buffer<float, 2> { outBufRange };
+      auto filterBuf = sycl::buffer { filter.data(), filterRange };
       outBuf.set_final_data(outputImage.data());
 
       auto inBufVec = inBuf.reinterpret<sycl::float4>(inBufRange /
@@ -75,10 +75,10 @@ int main() {
 
       util::benchmark(
           [&] {
-            myQueue.submit([&](sycl::handler &cgh) {
-              sycl::accessor inputAcc{inBufVec, cgh, sycl::read_only};
-              sycl::accessor outputAcc{outBufVec, cgh, sycl::write_only};
-              sycl::accessor filterAcc{filterBufVec, cgh, sycl::read_only};
+            myQueue.submit([&](sycl::handler& cgh) {
+              sycl::accessor inputAcc { inBufVec, cgh, sycl::read_only };
+              sycl::accessor outputAcc { outBufVec, cgh, sycl::write_only };
+              sycl::accessor filterAcc { filterBufVec, cgh, sycl::read_only };
 
               auto scratchpad =
                   sycl::local_accessor<sycl::float4, 2>(scratchpadRange, cgh);
@@ -128,7 +128,7 @@ int main() {
 
                     sycl::group_barrier(item.get_group());
 
-                    auto sum = sycl::float4{0.0f, 0.0f, 0.0f, 0.0f};
+                    auto sum = sycl::float4 { 0.0f, 0.0f, 0.0f, 0.0f };
 
                     for (int r = 0; r < filterWidth; ++r) {
                       for (int c = 0; c < filterWidth; ++c) {
@@ -145,7 +145,7 @@ int main() {
           },
           100, "image convolution (tiled)");
     }
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/Local_Memory_Tiling/solution.cpp
+++ b/Code_Exercises/Local_Memory_Tiling/solution.cpp
@@ -8,6 +8,8 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
+
 #include <algorithm>
 #include <iostream>
 
@@ -149,5 +151,5 @@ int main() {
 
   util::write_image(outputImage, outputImageFile);
 
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Local_Memory_Tiling/source.cpp
+++ b/Code_Exercises/Local_Memory_Tiling/source.cpp
@@ -8,10 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
 
-TEST_CASE("image_convolution_tiled", "local_memory_tiling_source") {
+int main() {
   // Use your code from Exercise 17 to start
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Local_Memory_Tiling/source.cpp
+++ b/Code_Exercises/Local_Memory_Tiling/source.cpp
@@ -8,9 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include <cassert>
+#include "../helpers.hpp"
 
 int main() {
   // Use your code from Exercise 17 to start
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Managing_Data/solution.cpp
+++ b/Code_Exercises/Managing_Data/solution.cpp
@@ -8,6 +8,7 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
 
 #include <sycl/sycl.hpp>
 
@@ -37,7 +38,7 @@ void test_usm() {
   sycl::free(dev_B, defaultQueue);
   sycl::free(dev_R, defaultQueue);
 
-  assert(r == 42);
+  SYCLACADEMY_ASSERT(r == 42);
 }
 
 void test_buffer() {
@@ -61,7 +62,7 @@ void test_buffer() {
         .wait();
   }
 
-  assert(r == 42);
+  SYCLACADEMY_ASSERT(r == 42);
 }
 
 int main() {

--- a/Code_Exercises/Managing_Data/solution.cpp
+++ b/Code_Exercises/Managing_Data/solution.cpp
@@ -8,15 +8,13 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
 
 #include <sycl/sycl.hpp>
 
 class scalar_add_usm;
 class scalar_add_buff_acc;
 
-TEST_CASE("scalar_add_usm", "scalar_add_solution") {
+void test_usm() {
   int a = 18, b = 24, r = 0;
 
   auto defaultQueue = sycl::queue{};
@@ -39,10 +37,10 @@ TEST_CASE("scalar_add_usm", "scalar_add_solution") {
   sycl::free(dev_B, defaultQueue);
   sycl::free(dev_R, defaultQueue);
 
-  REQUIRE(r == 42);
+  assert(r == 42);
 }
 
-TEST_CASE("scalar_add_buff_acc", "scalar_add_solution") {
+void test_buffer() {
   int a = 18, b = 24, r = 0;
 
   auto defaultQueue = sycl::queue{};
@@ -63,5 +61,10 @@ TEST_CASE("scalar_add_buff_acc", "scalar_add_solution") {
         .wait();
   }
 
-  REQUIRE(r == 42);
+  assert(r == 42);
+}
+
+int main() {
+  test_usm();
+  test_buffer();
 }

--- a/Code_Exercises/Managing_Data/solution.cpp
+++ b/Code_Exercises/Managing_Data/solution.cpp
@@ -18,7 +18,7 @@ class scalar_add_buff_acc;
 void test_usm() {
   int a = 18, b = 24, r = 0;
 
-  auto defaultQueue = sycl::queue{};
+  auto defaultQueue = sycl::queue {};
 
   auto dev_A = sycl::malloc_device<int>(1, defaultQueue);
   auto dev_B = sycl::malloc_device<int>(1, defaultQueue);
@@ -28,9 +28,11 @@ void test_usm() {
   defaultQueue.memcpy(dev_B, &b, 1 * sizeof(int)).wait();
 
   defaultQueue
-      .submit([&](sycl::handler &cgh) {
-        cgh.single_task<scalar_add_usm>([=] { dev_R[0] = dev_A[0] + dev_B[0]; });
-      }).wait();
+      .submit([&](sycl::handler& cgh) {
+        cgh.single_task<scalar_add_usm>(
+            [=] { dev_R[0] = dev_A[0] + dev_B[0]; });
+      })
+      .wait();
 
   defaultQueue.memcpy(&r, dev_R, 1 * sizeof(int)).wait();
 
@@ -44,20 +46,21 @@ void test_usm() {
 void test_buffer() {
   int a = 18, b = 24, r = 0;
 
-  auto defaultQueue = sycl::queue{};
+  auto defaultQueue = sycl::queue {};
 
   {
-    auto bufA = sycl::buffer{&a, sycl::range{1}};
-    auto bufB = sycl::buffer{&b, sycl::range{1}};
-    auto bufR = sycl::buffer{&r, sycl::range{1}};
+    auto bufA = sycl::buffer { &a, sycl::range { 1 } };
+    auto bufB = sycl::buffer { &b, sycl::range { 1 } };
+    auto bufR = sycl::buffer { &r, sycl::range { 1 } };
 
     defaultQueue
-        .submit([&](sycl::handler &cgh) {
-          auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
-          auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
-          auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
+        .submit([&](sycl::handler& cgh) {
+          auto accA = sycl::accessor { bufA, cgh, sycl::read_only };
+          auto accB = sycl::accessor { bufB, cgh, sycl::read_only };
+          auto accR = sycl::accessor { bufR, cgh, sycl::write_only };
 
-          cgh.single_task<scalar_add_buff_acc>([=] { accR[0] = accA[0] + accB[0]; });
+          cgh.single_task<scalar_add_buff_acc>(
+              [=] { accR[0] = accA[0] + accB[0]; });
         })
         .wait();
   }

--- a/Code_Exercises/Managing_Data/source.cpp
+++ b/Code_Exercises/Managing_Data/source.cpp
@@ -45,20 +45,19 @@
  *
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
 
-TEST_CASE("scalar_add_usm", "scalar_add_source") {
+void test_usm() {
 
   int a = 18, b = 24, r = 0;
 
   // Task: Compute a+b on the SYCL device using USM
   r = a + b;
 
-  REQUIRE(r == 42);
+  assert(r == 42);
 }
 
-TEST_CASE("scalar_add_buff_acc", "scalar_add_source") {
+void test_buffer() {
 
   int a = 18, b = 24, r = 0;
 
@@ -66,5 +65,10 @@ TEST_CASE("scalar_add_buff_acc", "scalar_add_source") {
   // accessor memory model
   r = a + b;
 
-  REQUIRE(r == 42);
+  assert(r == 42);
+}
+
+int main() {
+  test_usm();
+  test_buffer();
 }

--- a/Code_Exercises/Managing_Data/source.cpp
+++ b/Code_Exercises/Managing_Data/source.cpp
@@ -45,7 +45,7 @@
  *
 */
 
-#include <cassert>
+#include "../helpers.hpp"
 
 void test_usm() {
 
@@ -54,7 +54,7 @@ void test_usm() {
   // Task: Compute a+b on the SYCL device using USM
   r = a + b;
 
-  assert(r == 42);
+  SYCLACADEMY_ASSERT(r == 42);
 }
 
 void test_buffer() {
@@ -65,7 +65,7 @@ void test_buffer() {
   // accessor memory model
   r = a + b;
 
-  assert(r == 42);
+  SYCLACADEMY_ASSERT(r == 42);
 }
 
 int main() {

--- a/Code_Exercises/Matrix_Transpose/solution.cpp
+++ b/Code_Exercises/Matrix_Transpose/solution.cpp
@@ -134,7 +134,7 @@ int main() {
           },
           numIters, "Tiled local memory matrix transpose");
     }
-  } catch (const sycl::exception& e) {
+  } catch (const sycl::exception &e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/Matrix_Transpose/solution.cpp
+++ b/Code_Exercises/Matrix_Transpose/solution.cpp
@@ -71,30 +71,30 @@ int main() {
   }
 
   try {
-    auto q = sycl::queue{};
+    auto q = sycl::queue {};
 
     std::cout << "Running on "
               << q.get_device().get_info<sycl::info::device::name>() << "\n";
 
-    sycl::range globalRange{N, N};
-    sycl::range localRange{16, 16};
-    sycl::nd_range ndRange{globalRange, localRange};
+    sycl::range globalRange { N, N };
+    sycl::range localRange { 16, 16 };
+    sycl::nd_range ndRange { globalRange, localRange };
 
     {
-      sycl::buffer inBuf{A.data(), globalRange};
-      sycl::buffer outBuf{A_T.data(), globalRange};
-      sycl::buffer compBuf{A_T_comparison.data(), globalRange};
+      sycl::buffer inBuf { A.data(), globalRange };
+      sycl::buffer outBuf { A_T.data(), globalRange };
+      sycl::buffer compBuf { A_T_comparison.data(), globalRange };
 
       util::benchmark(
           [&]() {
-            q.submit([&](sycl::handler &cgh) {
-              sycl::accessor inAcc{inBuf, cgh, sycl::read_only};
-              sycl::accessor compAcc{compBuf, cgh, sycl::write_only,
-                                     sycl::property::no_init{}};
+            q.submit([&](sycl::handler& cgh) {
+              sycl::accessor inAcc { inBuf, cgh, sycl::read_only };
+              sycl::accessor compAcc { compBuf, cgh, sycl::write_only,
+                                       sycl::property::no_init {} };
 
               cgh.parallel_for<naive>(ndRange, [=](sycl::nd_item<2> item) {
                 auto globalId = item.get_global_id();
-                sycl::id globalIdTranspose{globalId[1], globalId[0]};
+                sycl::id globalIdTranspose { globalId[1], globalId[0] };
                 compAcc[globalIdTranspose] = inAcc[globalId];
               });
             });
@@ -104,20 +104,20 @@ int main() {
 
       util::benchmark(
           [&]() {
-            q.submit([&](sycl::handler &cgh) {
-              sycl::accessor inAcc{inBuf, cgh, sycl::read_only};
-              sycl::accessor outAcc{outBuf, cgh, sycl::write_only,
-                                    sycl::property::no_init{}};
-              sycl::local_accessor<T, 2> localAcc{localRange, cgh};
+            q.submit([&](sycl::handler& cgh) {
+              sycl::accessor inAcc { inBuf, cgh, sycl::read_only };
+              sycl::accessor outAcc { outBuf, cgh, sycl::write_only,
+                                      sycl::property::no_init {} };
+              sycl::local_accessor<T, 2> localAcc { localRange, cgh };
 
               cgh.parallel_for<tiled>(ndRange, [=](sycl::nd_item<2> item) {
                 // This kernel assumes that localRange[0] == localRange[1]
                 auto globalId = item.get_global_id();
                 auto localId = item.get_local_id();
-                auto localId_T = sycl::range{localId[1], localId[0]};
+                auto localId_T = sycl::range { localId[1], localId[0] };
                 auto groupOffset = globalId - localId;
                 auto groupOffset_T =
-                    sycl::range{groupOffset[1], groupOffset[0]};
+                    sycl::range { groupOffset[1], groupOffset[0] };
 
                 // Read from global memory in row major and write to local
                 // memory in column major
@@ -136,7 +136,7 @@ int main() {
           },
           numIters, "Tiled local memory matrix transpose");
     }
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/Matrix_Transpose/solution.cpp
+++ b/Code_Exercises/Matrix_Transpose/solution.cpp
@@ -43,6 +43,8 @@ InTile:               OutTile:
 
 */
 
+#include "../helpers.hpp"
+
 #include <iostream>
 #include <vector>
 
@@ -139,6 +141,6 @@ int main() {
   }
 
   for (auto i = 0; i < N * N; ++i) {
-    assert(A_T[i] == A_T_comparison[i]);
+    SYCLACADEMY_ASSERT(A_T[i] == A_T_comparison[i]);
   }
 }

--- a/Code_Exercises/Matrix_Transpose/source.cpp
+++ b/Code_Exercises/Matrix_Transpose/source.cpp
@@ -39,30 +39,30 @@ int main() {
   }
 
   try {
-    auto q = sycl::queue{};
+    auto q = sycl::queue {};
 
     std::cout << "Running on "
               << q.get_device().get_info<sycl::info::device::name>() << "\n";
 
-    sycl::range globalRange{N, N};
-    sycl::range localRange{16, 16};
-    sycl::nd_range ndRange{globalRange, localRange};
+    sycl::range globalRange { N, N };
+    sycl::range localRange { 16, 16 };
+    sycl::nd_range ndRange { globalRange, localRange };
 
     {
-      sycl::buffer inBuf{A.data(), globalRange};
-      sycl::buffer outBuf{A_T.data(), globalRange};
-      sycl::buffer compBuf{A_T_comparison.data(), globalRange};
+      sycl::buffer inBuf { A.data(), globalRange };
+      sycl::buffer outBuf { A_T.data(), globalRange };
+      sycl::buffer compBuf { A_T_comparison.data(), globalRange };
 
       util::benchmark(
           [&]() {
-            q.submit([&](sycl::handler &cgh) {
-              sycl::accessor inAcc{inBuf, cgh, sycl::read_only};
-              sycl::accessor compAcc{compBuf, cgh, sycl::write_only,
-                                     sycl::property::no_init{}};
+            q.submit([&](sycl::handler& cgh) {
+              sycl::accessor inAcc { inBuf, cgh, sycl::read_only };
+              sycl::accessor compAcc { compBuf, cgh, sycl::write_only,
+                                       sycl::property::no_init {} };
 
               cgh.parallel_for(ndRange, [=](sycl::nd_item<2> item) {
                 auto globalId = item.get_global_id();
-                auto globalIdTranspose = sycl::id{globalId[1], globalId[0]};
+                auto globalIdTranspose = sycl::id { globalId[1], globalId[0] };
                 compAcc[globalIdTranspose] = inAcc[globalId];
               });
             });
@@ -72,7 +72,7 @@ int main() {
 
       util::benchmark(
           [&]() {
-            q.submit([&](sycl::handler &cgh) {
+            q.submit([&](sycl::handler& cgh) {
               // TODO implement a tiled local memory matrix transpose.
             });
             q.wait_and_throw();

--- a/Code_Exercises/Matrix_Transpose/source.cpp
+++ b/Code_Exercises/Matrix_Transpose/source.cpp
@@ -14,6 +14,8 @@
  sycl::local_accessor<T, dims> local_acc{localRange, cgh};
 */
 
+#include "../helpers.hpp"
+
 #include <iostream>
 #include <vector>
 
@@ -82,6 +84,6 @@ int main() {
   }
 
   for (auto i = 0; i < N * N; ++i) {
-    assert(A_T[i] == A_T_comparison[i]);
+    SYCLACADEMY_ASSERT(A_T[i] == A_T_comparison[i]);
   }
 }

--- a/Code_Exercises/More_SYCL_Features/reduce_atomic.cpp
+++ b/Code_Exercises/More_SYCL_Features/reduce_atomic.cpp
@@ -12,6 +12,8 @@
  *
  */
 
+#include "../helpers.hpp"
+
 #include <benchmark.h>
 #include <sycl/sycl.hpp>
 

--- a/Code_Exercises/More_SYCL_Features/reduce_atomic.cpp
+++ b/Code_Exercises/More_SYCL_Features/reduce_atomic.cpp
@@ -25,19 +25,19 @@ constexpr size_t dataSize = 32'768;
 constexpr size_t workGroupSize = 1024;
 constexpr int numIters = 100;
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
 
   T a[dataSize];
-  T devAns[2] = {0, 0};
+  T devAns[2] = { 0, 0 };
 
   for (auto i = 0; i < dataSize; ++i) {
     a[i] = static_cast<T>(i);
   }
 
-  auto q = sycl::queue{};
+  auto q = sycl::queue {};
 
-  T *devA = sycl::malloc_device<T>(dataSize, q);
-  T *devReduced = sycl::malloc_device<T>(1, q); // Holds intermediate values
+  T* devA = sycl::malloc_device<T>(dataSize, q);
+  T* devReduced = sycl::malloc_device<T>(1, q); // Holds intermediate values
 
   T zeroVal = 0;
   auto e1 = q.memcpy(devA, a, sizeof(T) * dataSize);
@@ -47,8 +47,8 @@ int main(int argc, char *argv[]) {
 
   util::benchmark(
       [&]() {
-        q.submit([&](sycl::handler &cgh) {
-           cgh.depends_on({e1, e2});
+        q.submit([&](sycl::handler& cgh) {
+           cgh.depends_on({ e1, e2 });
 
            cgh.parallel_for(myNd, [=](sycl::nd_item<1> item) {
              auto globalIdx = item.get_global_linear_id();
@@ -66,8 +66,8 @@ int main(int argc, char *argv[]) {
 
   util::benchmark(
       [&]() {
-        q.submit([&](sycl::handler &cgh) {
-           cgh.depends_on({e1, e2});
+        q.submit([&](sycl::handler& cgh) {
+           cgh.depends_on({ e1, e2 });
            sycl::local_accessor<T, 1> localMem(workGroupSize, cgh);
            sycl::local_accessor<T, 1> localReduction(1, cgh);
 

--- a/Code_Exercises/More_SYCL_Features/reduce_group_algorithms.cpp
+++ b/Code_Exercises/More_SYCL_Features/reduce_group_algorithms.cpp
@@ -19,7 +19,7 @@ constexpr size_t dataSize = 32'768;
 constexpr size_t workGroupSize = 1024;
 constexpr int numIters = 100;
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
 
   T a[dataSize];
 
@@ -27,10 +27,10 @@ int main(int argc, char *argv[]) {
     a[i] = static_cast<T>(i);
   }
 
-  auto q = sycl::queue{};
+  auto q = sycl::queue {};
 
-  T *devA = sycl::malloc_device<T>(dataSize, q);
-  T *devReduced = sycl::malloc_device<T>(1, q); // Holds reduction output
+  T* devA = sycl::malloc_device<T>(dataSize, q);
+  T* devReduced = sycl::malloc_device<T>(1, q); // Holds reduction output
 
   auto e1 = q.memcpy(devA, a, sizeof(T) * dataSize);
   auto e2 = q.fill(devReduced, 0, 1);
@@ -39,8 +39,8 @@ int main(int argc, char *argv[]) {
 
   util::benchmark(
       [&]() {
-        q.submit([&](sycl::handler &cgh) {
-           cgh.depends_on({e1, e2});
+        q.submit([&](sycl::handler& cgh) {
+           cgh.depends_on({ e1, e2 });
            sycl::local_accessor<T, 1> localMem(workGroupSize, cgh);
 
            cgh.parallel_for(myNd, [=](sycl::nd_item<1> item) {

--- a/Code_Exercises/More_SYCL_Features/reduce_group_algorithms.cpp
+++ b/Code_Exercises/More_SYCL_Features/reduce_group_algorithms.cpp
@@ -8,6 +8,8 @@
  *
  */
 
+#include "../helpers.hpp"
+
 #include <benchmark.h>
 #include <sycl/sycl.hpp>
 

--- a/Code_Exercises/More_SYCL_Features/reduce_naive.cpp
+++ b/Code_Exercises/More_SYCL_Features/reduce_naive.cpp
@@ -30,7 +30,7 @@ constexpr int numIters = 100;
 // at a[0].
 template <typename T, size_t workGroupSize>
 inline void workgroup_reduce_local_mem(sycl::local_accessor<T, 1> a,
-                                       sycl::nd_item<1> &item,
+                                       sycl::nd_item<1>& item,
                                        size_t localIdx) {
 #pragma unroll
   for (auto i = workGroupSize; i >= 2; i /= 2) {
@@ -42,7 +42,7 @@ inline void workgroup_reduce_local_mem(sycl::local_accessor<T, 1> a,
   }
 }
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
 
   T a[dataSize];
 
@@ -50,10 +50,10 @@ int main(int argc, char *argv[]) {
     a[i] = static_cast<T>(i);
   }
 
-  auto q = sycl::queue{};
+  auto q = sycl::queue {};
 
-  T *devPtrA = sycl::malloc_device<T>(dataSize, q);
-  T *devPtrB =
+  T* devPtrA = sycl::malloc_device<T>(dataSize, q);
+  T* devPtrB =
       sycl::malloc_device<T>(numWorkGroups, q); // Holds intermediate values
 
   auto e1 = q.memcpy(devPtrA, a, sizeof(T) * dataSize);
@@ -63,7 +63,7 @@ int main(int argc, char *argv[]) {
 
   util::benchmark(
       [&]() {
-        auto e2 = q.submit([&](sycl::handler &cgh) {
+        auto e2 = q.submit([&](sycl::handler& cgh) {
           cgh.depends_on(e1);
           sycl::local_accessor<T, 1> local_mem(workGroupSize, cgh);
 
@@ -89,7 +89,7 @@ int main(int argc, char *argv[]) {
               });
         });
 
-        q.submit([&](sycl::handler &cgh) {
+        q.submit([&](sycl::handler& cgh) {
            cgh.depends_on(e2);
            sycl::local_accessor<T, 1> local_mem(workGroupSize, cgh);
 

--- a/Code_Exercises/More_SYCL_Features/reduce_naive.cpp
+++ b/Code_Exercises/More_SYCL_Features/reduce_naive.cpp
@@ -11,6 +11,8 @@
  *
  */
 
+#include "../helpers.hpp"
+
 #include <benchmark.h>
 #include <sycl/sycl.hpp>
 

--- a/Code_Exercises/More_SYCL_Features/reduce_sycl_reduction.cpp
+++ b/Code_Exercises/More_SYCL_Features/reduce_sycl_reduction.cpp
@@ -4,6 +4,8 @@
  *
  */
 
+#include "../helpers.hpp"
+
 #include <benchmark.h>
 #include <sycl/sycl.hpp>
 

--- a/Code_Exercises/More_SYCL_Features/reduce_sycl_reduction.cpp
+++ b/Code_Exercises/More_SYCL_Features/reduce_sycl_reduction.cpp
@@ -15,7 +15,7 @@ constexpr size_t dataSize = 32'768;
 constexpr size_t workGroupSize = 1024;
 constexpr int numIters = 100;
 
-int main(int argc, char *argv[]) {
+int main(int argc, char* argv[]) {
 
   T a[dataSize];
 
@@ -23,10 +23,10 @@ int main(int argc, char *argv[]) {
     a[i] = static_cast<T>(i);
   }
 
-  auto q = sycl::queue{};
+  auto q = sycl::queue {};
 
-  T *devA = sycl::malloc_device<T>(dataSize, q);
-  T *devReduced = sycl::malloc_device<T>(1, q); // Holds intermediate values
+  T* devA = sycl::malloc_device<T>(dataSize, q);
+  T* devReduced = sycl::malloc_device<T>(1, q); // Holds intermediate values
 
   T zeroVal = 0;
   auto e1 = q.memcpy(devA, a, sizeof(T) * dataSize);
@@ -36,14 +36,14 @@ int main(int argc, char *argv[]) {
 
   util::benchmark(
       [&]() {
-        q.submit([&](sycl::handler &cgh) {
-           cgh.depends_on({e1, e2});
+        q.submit([&](sycl::handler& cgh) {
+           cgh.depends_on({ e1, e2 });
            auto myReduction = sycl::reduction(
                devReduced, sycl::plus<T>(),
-               sycl::property::reduction::initialize_to_identity{});
+               sycl::property::reduction::initialize_to_identity {});
 
            cgh.parallel_for(myNd, myReduction,
-                            [=](sycl::nd_item<1> item, auto &sum) {
+                            [=](sycl::nd_item<1> item, auto& sum) {
                               sum += devA[item.get_global_linear_id()];
                             });
          }).wait();

--- a/Code_Exercises/Multiple_Devices/solution.cpp
+++ b/Code_Exercises/Multiple_Devices/solution.cpp
@@ -24,8 +24,8 @@ std::vector<sycl::device> get_two_devices() {
   if (devs.size() == 0)
     throw "No devices available";
   if (devs.size() == 1)
-    return {devs[0], devs[0]};
-  return {devs[0], devs[1]};
+    return { devs[0], devs[0] };
+  return { devs[0], devs[1] };
 }
 
 int main() {
@@ -43,9 +43,9 @@ int main() {
 
   try {
     auto devs = get_two_devices();
-    auto Q1 = sycl::queue{devs[0]};
-    auto Q2 = sycl::queue{devs[1]}; // if only one device is found, both queues
-                                    // will use same device
+    auto Q1 = sycl::queue { devs[0] };
+    auto Q2 = sycl::queue { devs[1] }; // if only one device is found, both
+                                       // queues will use same device
 
     std::cout << "Running on devices:" << std::endl;
     std::cout << "1:\t" << Q1.get_device().get_info<sycl::info::device::name>()
@@ -53,40 +53,40 @@ int main() {
     std::cout << "2:\t" << Q2.get_device().get_info<sycl::info::device::name>()
               << std::endl;
 
-    auto bufFirstA = sycl::buffer{a, sycl::range{dataSizeFirst}};
-    auto bufFirstB = sycl::buffer{b, sycl::range{dataSizeFirst}};
-    auto bufFirstR = sycl::buffer{r, sycl::range{dataSizeFirst}};
+    auto bufFirstA = sycl::buffer { a, sycl::range { dataSizeFirst } };
+    auto bufFirstB = sycl::buffer { b, sycl::range { dataSizeFirst } };
+    auto bufFirstR = sycl::buffer { r, sycl::range { dataSizeFirst } };
 
     auto bufSecondA =
-        sycl::buffer{a + dataSizeFirst, sycl::range{dataSizeSecond}};
+        sycl::buffer { a + dataSizeFirst, sycl::range { dataSizeSecond } };
     auto bufSecondB =
-        sycl::buffer{b + dataSizeFirst, sycl::range{dataSizeSecond}};
+        sycl::buffer { b + dataSizeFirst, sycl::range { dataSizeSecond } };
     auto bufSecondR =
-        sycl::buffer{r + dataSizeFirst, sycl::range{dataSizeSecond}};
+        sycl::buffer { r + dataSizeFirst, sycl::range { dataSizeSecond } };
 
-    Q1.submit([&](sycl::handler &cgh) {
-      sycl::accessor accA{bufFirstA, cgh, sycl::read_only};
-      sycl::accessor accB{bufFirstB, cgh, sycl::read_only};
-      sycl::accessor accR{bufFirstR, cgh, sycl::write_only};
+    Q1.submit([&](sycl::handler& cgh) {
+      sycl::accessor accA { bufFirstA, cgh, sycl::read_only };
+      sycl::accessor accB { bufFirstB, cgh, sycl::read_only };
+      sycl::accessor accR { bufFirstR, cgh, sycl::write_only };
 
       cgh.parallel_for<vector_add_first>(
-          sycl::range{dataSizeFirst},
+          sycl::range { dataSizeFirst },
           [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
     });
 
-    Q2.submit([&](sycl::handler &cgh) {
-      sycl::accessor accA{bufSecondA, cgh, sycl::read_only};
-      sycl::accessor accB{bufSecondB, cgh, sycl::read_only};
-      sycl::accessor accR{bufSecondR, cgh, sycl::write_only};
+    Q2.submit([&](sycl::handler& cgh) {
+      sycl::accessor accA { bufSecondA, cgh, sycl::read_only };
+      sycl::accessor accB { bufSecondB, cgh, sycl::read_only };
+      sycl::accessor accR { bufSecondR, cgh, sycl::write_only };
 
       cgh.parallel_for<vector_add_second>(
-          sycl::range{dataSizeSecond},
+          sycl::range { dataSizeSecond },
           [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
     });
 
     Q1.wait_and_throw();
     Q2.wait_and_throw();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/Multiple_Devices/solution.cpp
+++ b/Code_Exercises/Multiple_Devices/solution.cpp
@@ -8,6 +8,8 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
+
 #include <sycl/sycl.hpp>
 
 #include <algorithm>
@@ -89,6 +91,6 @@ int main() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(r[i] == static_cast<float>(i) * 2.0f);
+    SYCLACADEMY_ASSERT(r[i] == static_cast<float>(i) * 2.0f);
   }
 }

--- a/Code_Exercises/Multiple_Devices/solution.cpp
+++ b/Code_Exercises/Multiple_Devices/solution.cpp
@@ -8,9 +8,6 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 #include <sycl/sycl.hpp>
 
 #include <algorithm>
@@ -29,7 +26,7 @@ std::vector<sycl::device> get_two_devices() {
   return {devs[0], devs[1]};
 }
 
-TEST_CASE("load_balancing", "load_balancing_solution") {
+int main() {
   constexpr size_t dataSize = 1024;
   constexpr float ratio = 0.5f;
   constexpr size_t dataSizeFirst = ratio * dataSize;
@@ -92,6 +89,6 @@ TEST_CASE("load_balancing", "load_balancing_solution") {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    REQUIRE(r[i] == static_cast<float>(i) * 2.0f);
+    assert(r[i] == static_cast<float>(i) * 2.0f);
   }
 }

--- a/Code_Exercises/Multiple_Devices/source.cpp
+++ b/Code_Exercises/Multiple_Devices/source.cpp
@@ -35,17 +35,18 @@
  *              // Do something
  *          });
  * //    3. Enqueue a parallel for:
- *          cgh.parallel_for<class mykernel>(sycl::range{n}, [=](sycl::id<1> i) {
+ *          cgh.parallel_for<class mykernel>(sycl::range{n}, [=](sycl::id<1> i)
+ {
  *              // Do something
  *          });
  *
 
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
+#include <cstddef>
 
-TEST_CASE("load_balancing", "load_balancing_source") {
+int main() {
   constexpr size_t dataSize = 1024;
   constexpr float ratio = 0.5f;
   constexpr size_t dataSizeFirst = ratio * dataSize;
@@ -72,6 +73,6 @@ TEST_CASE("load_balancing", "load_balancing_source") {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    REQUIRE(r[i] == static_cast<float>(i) * 2.0f);
+    assert(r[i] == static_cast<float>(i) * 2.0f);
   }
 }

--- a/Code_Exercises/Multiple_Devices/source.cpp
+++ b/Code_Exercises/Multiple_Devices/source.cpp
@@ -43,8 +43,7 @@
 
 */
 
-#include <cassert>
-#include <cstddef>
+#include "../helpers.hpp"
 
 int main() {
   constexpr size_t dataSize = 1024;
@@ -73,6 +72,6 @@ int main() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(r[i] == static_cast<float>(i) * 2.0f);
+    SYCLACADEMY_ASSERT(r[i] == static_cast<float>(i) * 2.0f);
   }
 }

--- a/Code_Exercises/ND_Range_Kernel/solution.cpp
+++ b/Code_Exercises/ND_Range_Kernel/solution.cpp
@@ -8,6 +8,8 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
+
 #include <sycl/sycl.hpp>
 
 class vector_add_1;
@@ -48,7 +50,7 @@ void test_item() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(r[i] == i * 2);
+    SYCLACADEMY_ASSERT(r[i] == i * 2);
   }
 }
 
@@ -90,7 +92,7 @@ void test_nd_item() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(r[i] == i * 2);
+    SYCLACADEMY_ASSERT(r[i] == i * 2);
   }
 }
 

--- a/Code_Exercises/ND_Range_Kernel/solution.cpp
+++ b/Code_Exercises/ND_Range_Kernel/solution.cpp
@@ -8,15 +8,12 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 #include <sycl/sycl.hpp>
 
 class vector_add_1;
 class vector_add_2;
 
-TEST_CASE("range_kernel_with_item", "nd_range_kernel_solution") {
+void test_item() {
   constexpr size_t dataSize = 1024;
 
   int a[dataSize], b[dataSize], r[dataSize];
@@ -33,7 +30,7 @@ TEST_CASE("range_kernel_with_item", "nd_range_kernel_solution") {
     auto bufB = sycl::buffer{b, sycl::range{dataSize}};
     auto bufR = sycl::buffer{r, sycl::range{dataSize}};
 
-    gpuQueue.submit([&](sycl::handler& cgh) {
+    gpuQueue.submit([&](sycl::handler &cgh) {
       sycl::accessor accA{bufA, cgh, sycl::read_only};
       sycl::accessor accB{bufB, cgh, sycl::read_only};
       sycl::accessor accR{bufR, cgh, sycl::write_only};
@@ -46,16 +43,16 @@ TEST_CASE("range_kernel_with_item", "nd_range_kernel_solution") {
     });
 
     gpuQueue.throw_asynchronous();
-  } catch (const sycl::exception& e) {
+  } catch (const sycl::exception &e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    REQUIRE(r[i] == i * 2);
+    assert(r[i] == i * 2);
   }
 }
 
-TEST_CASE("nd_range_kernel", "nd_range_kernel_solution") {
+void test_nd_item() {
   constexpr size_t dataSize = 1024;
   constexpr size_t workGroupSize = 128;
 
@@ -73,7 +70,7 @@ TEST_CASE("nd_range_kernel", "nd_range_kernel_solution") {
     auto bufB = sycl::buffer{b, sycl::range{dataSize}};
     auto bufR = sycl::buffer{r, sycl::range{dataSize}};
 
-    gpuQueue.submit([&](sycl::handler& cgh) {
+    gpuQueue.submit([&](sycl::handler &cgh) {
       sycl::accessor accA{bufA, cgh, sycl::read_write};
       sycl::accessor accB{bufB, cgh, sycl::read_write};
       sycl::accessor accR{bufR, cgh, sycl::read_write};
@@ -88,11 +85,16 @@ TEST_CASE("nd_range_kernel", "nd_range_kernel_solution") {
     });
 
     gpuQueue.throw_asynchronous();
-  } catch (const sycl::exception& e) {
+  } catch (const sycl::exception &e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    REQUIRE(r[i] == i * 2);
+    assert(r[i] == i * 2);
   }
+}
+
+int main() {
+  test_item();
+  test_nd_item();
 }

--- a/Code_Exercises/ND_Range_Kernel/solution.cpp
+++ b/Code_Exercises/ND_Range_Kernel/solution.cpp
@@ -26,26 +26,26 @@ void test_item() {
   }
 
   try {
-    auto gpuQueue = sycl::queue{sycl::gpu_selector_v};
+    auto gpuQueue = sycl::queue { sycl::gpu_selector_v };
 
-    auto bufA = sycl::buffer{a, sycl::range{dataSize}};
-    auto bufB = sycl::buffer{b, sycl::range{dataSize}};
-    auto bufR = sycl::buffer{r, sycl::range{dataSize}};
+    auto bufA = sycl::buffer { a, sycl::range { dataSize } };
+    auto bufB = sycl::buffer { b, sycl::range { dataSize } };
+    auto bufR = sycl::buffer { r, sycl::range { dataSize } };
 
-    gpuQueue.submit([&](sycl::handler &cgh) {
-      sycl::accessor accA{bufA, cgh, sycl::read_only};
-      sycl::accessor accB{bufB, cgh, sycl::read_only};
-      sycl::accessor accR{bufR, cgh, sycl::write_only};
+    gpuQueue.submit([&](sycl::handler& cgh) {
+      sycl::accessor accA { bufA, cgh, sycl::read_only };
+      sycl::accessor accB { bufB, cgh, sycl::read_only };
+      sycl::accessor accR { bufR, cgh, sycl::write_only };
 
       cgh.parallel_for<vector_add_1>(
-          sycl::range{dataSize}, [=](sycl::item<1> itm) {
+          sycl::range { dataSize }, [=](sycl::item<1> itm) {
             auto globalId = itm.get_id();
             accR[globalId] = accA[globalId] + accB[globalId];
           });
     });
 
     gpuQueue.throw_asynchronous();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
@@ -66,19 +66,19 @@ void test_nd_item() {
   }
 
   try {
-    auto gpuQueue = sycl::queue{sycl::gpu_selector_v};
+    auto gpuQueue = sycl::queue { sycl::gpu_selector_v };
 
-    auto bufA = sycl::buffer{a, sycl::range{dataSize}};
-    auto bufB = sycl::buffer{b, sycl::range{dataSize}};
-    auto bufR = sycl::buffer{r, sycl::range{dataSize}};
+    auto bufA = sycl::buffer { a, sycl::range { dataSize } };
+    auto bufB = sycl::buffer { b, sycl::range { dataSize } };
+    auto bufR = sycl::buffer { r, sycl::range { dataSize } };
 
-    gpuQueue.submit([&](sycl::handler &cgh) {
-      sycl::accessor accA{bufA, cgh, sycl::read_write};
-      sycl::accessor accB{bufB, cgh, sycl::read_write};
-      sycl::accessor accR{bufR, cgh, sycl::read_write};
+    gpuQueue.submit([&](sycl::handler& cgh) {
+      sycl::accessor accA { bufA, cgh, sycl::read_write };
+      sycl::accessor accB { bufB, cgh, sycl::read_write };
+      sycl::accessor accR { bufR, cgh, sycl::read_write };
 
-      auto ndRange =
-          sycl::nd_range{sycl::range{dataSize}, sycl::range{workGroupSize}};
+      auto ndRange = sycl::nd_range { sycl::range { dataSize },
+                                      sycl::range { workGroupSize } };
 
       cgh.parallel_for<vector_add_2>(ndRange, [=](sycl::nd_item<1> itm) {
         auto globalId = itm.get_global_id();
@@ -87,7 +87,7 @@ void test_nd_item() {
     });
 
     gpuQueue.throw_asynchronous();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/ND_Range_Kernel/source.cpp
+++ b/Code_Exercises/ND_Range_Kernel/source.cpp
@@ -54,8 +54,7 @@
  *                      });
 */
 
-#include <cassert>
-#include <cstddef>
+#include "../helpers.hpp"
 
 int main() {
   constexpr size_t dataSize = 1024;
@@ -73,6 +72,6 @@ int main() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(r[i] == i * 2);
+    SYCLACADEMY_ASSERT(r[i] == i * 2);
   }
 }

--- a/Code_Exercises/ND_Range_Kernel/source.cpp
+++ b/Code_Exercises/ND_Range_Kernel/source.cpp
@@ -54,10 +54,10 @@
  *                      });
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
+#include <cstddef>
 
-TEST_CASE("nd_range_kernel", "nd_range_kernel_source") {
+int main() {
   constexpr size_t dataSize = 1024;
 
   int a[dataSize], b[dataSize], r[dataSize];
@@ -73,6 +73,6 @@ TEST_CASE("nd_range_kernel", "nd_range_kernel_source") {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    REQUIRE(r[i] == i * 2);
+    assert(r[i] == i * 2);
   }
 }

--- a/Code_Exercises/OneMKL_gemm/solution_onemkl_buffer_gemm.cpp
+++ b/Code_Exercises/OneMKL_gemm/solution_onemkl_buffer_gemm.cpp
@@ -36,7 +36,7 @@ using T = double;
 //////////////////////////////////////////////////////////////////////////////////////////
 
 bool ValueSame(T a, T b) { return std::fabs(a - b) < 1.0e-08; }
-int VerifyResult(sycl::host_accessor<T, 1> &c_A, T *c_B) {
+int VerifyResult(sycl::host_accessor<T, 1>& c_A, T* c_B) {
   bool MismatchFound = false;
 
   for (size_t i = 0; i < M; i++) {
@@ -61,7 +61,7 @@ int VerifyResult(sycl::host_accessor<T, 1> &c_A, T *c_B) {
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
-void print_device_info(sycl::queue &Q) {
+void print_device_info(sycl::queue& Q) {
   std::string sycl_dev_name, sycl_runtime, sycl_driver;
   sycl_dev_name = Q.get_device().get_info<sycl::info::device::name>();
   sycl_driver = Q.get_device().get_info<sycl::info::device::driver_version>();
@@ -120,15 +120,15 @@ int main() {
   }
 
   // Create a SYCL in-order queue targetting GPU device
-  sycl::queue Q{sycl::gpu_selector_v, sycl::property::queue::in_order{}};
+  sycl::queue Q { sycl::gpu_selector_v, sycl::property::queue::in_order {} };
   // Prints some basic info related to the hardware
   print_device_info(Q);
 
   // TODO: Allocate memory on device, (using sycl::malloc_device APIs)
   // Creating 1D buffers for matrices which are bound to host memory array
-  sycl::buffer<T, 1> a{A.data(), sycl::range<1>{M * N}};
-  sycl::buffer<T, 1> b{B.data(), sycl::range<1>{N * P}};
-  sycl::buffer<T, 1> c{C_host.data(), sycl::range<1>{M * P}};
+  sycl::buffer<T, 1> a { A.data(), sycl::range<1> { M * N } };
+  sycl::buffer<T, 1> b { B.data(), sycl::range<1> { N * P } };
+  sycl::buffer<T, 1> c { C_host.data(), sycl::range<1> { M * P } };
 
   // TODO: Use oneMKL GEMM USM API
   oneapi::mkl::transpose transA = oneapi::mkl::transpose::nontrans;
@@ -136,7 +136,7 @@ int main() {
   oneapi::mkl::blas::column_major::gemm(Q, transA, transB, n, m, k, alpha, b,
                                         ldB, a, ldA, beta, c, ldC);
   Q.wait();
-  sycl::host_accessor C_device{c};
+  sycl::host_accessor C_device { c };
 
   // Verify results from oneMKL APIs
   int result = 0;

--- a/Code_Exercises/OneMKL_gemm/solution_onemkl_usm_gemm.cpp
+++ b/Code_Exercises/OneMKL_gemm/solution_onemkl_usm_gemm.cpp
@@ -36,7 +36,7 @@ using T = double;
 //////////////////////////////////////////////////////////////////////////////////////////
 
 bool ValueSame(T a, T b) { return std::fabs(a - b) < 1.0e-08; }
-int VerifyResult(T *c_A, T *c_B) {
+int VerifyResult(T* c_A, T* c_B) {
   bool MismatchFound = false;
 
   for (size_t i = 0; i < M; i++) {
@@ -61,7 +61,7 @@ int VerifyResult(T *c_A, T *c_B) {
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
-void print_device_info(sycl::queue &Q) {
+void print_device_info(sycl::queue& Q) {
   std::string sycl_dev_name, sycl_runtime, sycl_driver;
   sycl_dev_name = Q.get_device().get_info<sycl::info::device::name>();
   sycl_driver = Q.get_device().get_info<sycl::info::device::driver_version>();
@@ -120,14 +120,14 @@ int main() {
   }
 
   // Create a SYCL in-order queue targetting GPU device
-  sycl::queue Q{sycl::gpu_selector_v, sycl::property::queue::in_order{}};
+  sycl::queue Q { sycl::gpu_selector_v, sycl::property::queue::in_order {} };
   // Prints some basic info related to the hardware
   print_device_info(Q);
 
   // TODO: Allocate memory on device, (using sycl::malloc_device APIs)
-  T *a = sycl::malloc_device<T>((M * N), Q);
-  T *b = sycl::malloc_device<T>((N * P), Q);
-  T *c = sycl::malloc_device<T>((M * P), Q);
+  T* a = sycl::malloc_device<T>((M * N), Q);
+  T* b = sycl::malloc_device<T>((N * P), Q);
+  T* c = sycl::malloc_device<T>((M * P), Q);
   Q.memcpy(a, A.data(), sizeof(T) * M * N);
   Q.memcpy(b, B.data(), sizeof(T) * N * P);
 

--- a/Code_Exercises/OneMKL_gemm/source_onemkl_buffer_gemm.cpp
+++ b/Code_Exercises/OneMKL_gemm/source_onemkl_buffer_gemm.cpp
@@ -36,7 +36,7 @@ using T = double;
 //////////////////////////////////////////////////////////////////////////////////////////
 
 bool ValueSame(T a, T b) { return std::fabs(a - b) < 1.0e-08; }
-int VerifyResult(sycl::host_accessor<T, 1> &c_A, T *c_B) {
+int VerifyResult(sycl::host_accessor<T, 1>& c_A, T* c_B) {
   bool MismatchFound = false;
 
   for (size_t i = 0; i < M; i++) {
@@ -61,7 +61,7 @@ int VerifyResult(sycl::host_accessor<T, 1> &c_A, T *c_B) {
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
-void print_device_info(sycl::queue &Q) {
+void print_device_info(sycl::queue& Q) {
   std::string sycl_dev_name, sycl_runtime, sycl_driver;
   sycl_dev_name = Q.get_device().get_info<sycl::info::device::name>();
   sycl_driver = Q.get_device().get_info<sycl::info::device::driver_version>();
@@ -120,7 +120,7 @@ int main() {
   }
 
   // Create a SYCL in-order queue targetting GPU device
-  sycl::queue Q{sycl::gpu_selector_v, sycl::property::queue::in_order{}};
+  sycl::queue Q { sycl::gpu_selector_v, sycl::property::queue::in_order {} };
   // Prints some basic info related to the hardware
   print_device_info(Q);
 

--- a/Code_Exercises/OneMKL_gemm/source_onemkl_usm_gemm.cpp
+++ b/Code_Exercises/OneMKL_gemm/source_onemkl_usm_gemm.cpp
@@ -36,7 +36,7 @@ using T = double;
 //////////////////////////////////////////////////////////////////////////////////////////
 
 bool ValueSame(T a, T b) { return std::fabs(a - b) < 1.0e-08; }
-int VerifyResult(T *c_A, T *c_B) {
+int VerifyResult(T* c_A, T* c_B) {
   bool MismatchFound = false;
 
   for (size_t i = 0; i < M; i++) {
@@ -61,7 +61,7 @@ int VerifyResult(T *c_A, T *c_B) {
 
 //////////////////////////////////////////////////////////////////////////////////////////
 
-void print_device_info(sycl::queue &Q) {
+void print_device_info(sycl::queue& Q) {
   std::string sycl_dev_name, sycl_runtime, sycl_driver;
   sycl_dev_name = Q.get_device().get_info<sycl::info::device::name>();
   sycl_driver = Q.get_device().get_info<sycl::info::device::driver_version>();
@@ -120,7 +120,7 @@ int main() {
   }
 
   // Create a SYCL in-order queue targetting GPU device
-  sycl::queue Q{sycl::gpu_selector_v, sycl::property::queue::in_order{}};
+  sycl::queue Q { sycl::gpu_selector_v, sycl::property::queue::in_order {} };
   // Prints some basic info related to the hardware
   print_device_info(Q);
 

--- a/Code_Exercises/Using_USM/solution.cpp
+++ b/Code_Exercises/Using_USM/solution.cpp
@@ -8,21 +8,18 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 #include <sycl/sycl.hpp>
 
 class vector_add;
 
-int usm_selector(const sycl::device& dev) {
+int usm_selector(const sycl::device &dev) {
   if (dev.has(sycl::aspect::usm_device_allocations)) {
     return 1;
   }
   return -1;
 }
 
-TEST_CASE("usm_vector_add", "usm_vector_add_solution") {
+int main() {
   constexpr size_t dataSize = 1024;
 
   float a[dataSize], b[dataSize], r[dataSize];
@@ -59,11 +56,11 @@ TEST_CASE("usm_vector_add", "usm_vector_add_solution") {
     sycl::free(devicePtrR, usmQueue);
 
     usmQueue.throw_asynchronous();
-  } catch (const sycl::exception& e) {
+  } catch (const sycl::exception &e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    REQUIRE(r[i] == i * 2);
+    assert(r[i] == i * 2);
   }
 }

--- a/Code_Exercises/Using_USM/solution.cpp
+++ b/Code_Exercises/Using_USM/solution.cpp
@@ -14,7 +14,7 @@
 
 class vector_add;
 
-int usm_selector(const sycl::device &dev) {
+int usm_selector(const sycl::device& dev) {
   if (dev.has(sycl::aspect::usm_device_allocations)) {
     return 1;
   }
@@ -32,7 +32,7 @@ int main() {
   }
 
   try {
-    auto usmQueue = sycl::queue{usm_selector};
+    auto usmQueue = sycl::queue { usm_selector };
 
     auto devicePtrA = sycl::malloc_device<float>(dataSize, usmQueue);
     auto devicePtrB = sycl::malloc_device<float>(dataSize, usmQueue);
@@ -42,7 +42,7 @@ int main() {
     usmQueue.memcpy(devicePtrB, b, sizeof(float) * dataSize).wait();
 
     usmQueue
-        .parallel_for<vector_add>(sycl::range{dataSize},
+        .parallel_for<vector_add>(sycl::range { dataSize },
                                   [=](sycl::id<1> idx) {
                                     auto globalId = idx[0];
                                     devicePtrR[globalId] =
@@ -58,7 +58,7 @@ int main() {
     sycl::free(devicePtrR, usmQueue);
 
     usmQueue.throw_asynchronous();
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/Using_USM/solution.cpp
+++ b/Code_Exercises/Using_USM/solution.cpp
@@ -8,6 +8,8 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
+
 #include <sycl/sycl.hpp>
 
 class vector_add;
@@ -61,6 +63,6 @@ int main() {
   }
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(r[i] == i * 2);
+    SYCLACADEMY_ASSERT(r[i] == i * 2);
   }
 }

--- a/Code_Exercises/Using_USM/source.cpp
+++ b/Code_Exercises/Using_USM/source.cpp
@@ -8,10 +8,10 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
+#include <cstddef>
 
-TEST_CASE("usm_vector_add", "usm_vector_add_source") {
+int main() {
   constexpr size_t dataSize = 1024;
 
   float a[dataSize], b[dataSize], r[dataSize];
@@ -28,6 +28,6 @@ TEST_CASE("usm_vector_add", "usm_vector_add_source") {
 
 
   for (int i = 0; i < dataSize; ++i) {
-    REQUIRE(r[i] == i * 2);
+    assert(r[i] == i * 2);
   }
 }

--- a/Code_Exercises/Using_USM/source.cpp
+++ b/Code_Exercises/Using_USM/source.cpp
@@ -20,11 +20,11 @@ int main() {
     r[i] = 0.0f;
   }
 
-  // Task: Allocate the arrays in USM, and compute r[i] = a[i] + b[i] on the SYCL device
+  // Task: Allocate the arrays in USM, and compute r[i] = a[i] + b[i] on the
+  // SYCL device
   for (int i = 0; i < dataSize; ++i) {
     r[i] = a[i] + b[i];
   }
-
 
   for (int i = 0; i < dataSize; ++i) {
     SYCLACADEMY_ASSERT(r[i] == i * 2);

--- a/Code_Exercises/Using_USM/source.cpp
+++ b/Code_Exercises/Using_USM/source.cpp
@@ -8,8 +8,7 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include <cassert>
-#include <cstddef>
+#include "../helpers.hpp"
 
 int main() {
   constexpr size_t dataSize = 1024;
@@ -28,6 +27,6 @@ int main() {
 
 
   for (int i = 0; i < dataSize; ++i) {
-    assert(r[i] == i * 2);
+    SYCLACADEMY_ASSERT(r[i] == i * 2);
   }
 }

--- a/Code_Exercises/Vectors/solution.cpp
+++ b/Code_Exercises/Vectors/solution.cpp
@@ -8,6 +8,8 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
+
 #include <algorithm>
 #include <iostream>
 
@@ -111,5 +113,5 @@ int main() {
 
   util::write_image(outputImage, outputImageFile);
 
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Vectors/solution.cpp
+++ b/Code_Exercises/Vectors/solution.cpp
@@ -25,8 +25,8 @@ inline constexpr int filterWidth = 11;
 inline constexpr int halo = filterWidth / 2;
 
 int main() {
-  const char *inputImageFile = "../Images/dogs.png";
-  const char *outputImageFile = "../Images/blurred_dogs.png";
+  const char* inputImageFile = "../Images/dogs.png";
+  const char* outputImageFile = "../Images/blurred_dogs.png";
 
   auto inputImage = util::read_image(inputImageFile, halo);
 
@@ -36,7 +36,7 @@ int main() {
   auto filter = util::generate_filter(util::filter_type::blur, filterWidth);
 
   try {
-    sycl::queue myQueue{sycl::gpu_selector_v};
+    sycl::queue myQueue { sycl::gpu_selector_v };
 
     std::cout << "Running on "
               << myQueue.get_device().get_info<sycl::info::device::name>()
@@ -60,9 +60,9 @@ int main() {
     auto filterRange = filterWidth * sycl::range(1, channels);
 
     {
-      auto inBuf = sycl::buffer{inputImage.data(), inBufRange};
-      auto outBuf = sycl::buffer<float, 2>{outBufRange};
-      auto filterBuf = sycl::buffer{filter.data(), filterRange};
+      auto inBuf = sycl::buffer { inputImage.data(), inBufRange };
+      auto outBuf = sycl::buffer<float, 2> { outBufRange };
+      auto filterBuf = sycl::buffer { filter.data(), filterRange };
       outBuf.set_final_data(outputImage.data());
 
       auto inBufVec = inBuf.reinterpret<sycl::float4>(inBufRange /
@@ -74,10 +74,10 @@ int main() {
 
       util::benchmark(
           [&]() {
-            myQueue.submit([&](sycl::handler &cgh) {
-              sycl::accessor inputAcc{inBufVec, cgh, sycl::read_only};
-              sycl::accessor outputAcc{outBufVec, cgh, sycl::write_only};
-              sycl::accessor filterAcc{filterBufVec, cgh, sycl::read_only};
+            myQueue.submit([&](sycl::handler& cgh) {
+              sycl::accessor inputAcc { inBufVec, cgh, sycl::read_only };
+              sycl::accessor outputAcc { outBufVec, cgh, sycl::write_only };
+              sycl::accessor filterAcc { filterBufVec, cgh, sycl::read_only };
 
               cgh.parallel_for<image_convolution>(
                   ndRange, [=](sycl::nd_item<2> item) {
@@ -87,7 +87,7 @@ int main() {
                     auto src = (globalId + haloOffset);
                     auto dest = globalId;
 
-                    auto sum = sycl::float4{0.0f, 0.0f, 0.0f, 0.0f};
+                    auto sum = sycl::float4 { 0.0f, 0.0f, 0.0f, 0.0f };
 
                     for (int r = 0; r < filterWidth; ++r) {
                       for (int c = 0; c < filterWidth; ++c) {
@@ -107,7 +107,7 @@ int main() {
           },
           100, "image convolution (vectorized)");
     }
-  } catch (const sycl::exception &e) {
+  } catch (const sycl::exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 

--- a/Code_Exercises/Vectors/solution.cpp
+++ b/Code_Exercises/Vectors/solution.cpp
@@ -11,14 +11,10 @@
 #include <algorithm>
 #include <iostream>
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 #include <sycl/sycl.hpp>
 
 #include <benchmark.h>
 #include <image_conv.h>
-
 
 class image_convolution;
 
@@ -26,11 +22,9 @@ inline constexpr util::filter_type filterType = util::filter_type::blur;
 inline constexpr int filterWidth = 11;
 inline constexpr int halo = filterWidth / 2;
 
-TEST_CASE("image_convolution_vectorized", "vectors_solution") {
-  const char* inputImageFile =
-      "../Images/dogs.png";
-  const char* outputImageFile =
-      "../Images/blurred_dogs.png";
+int main() {
+  const char *inputImageFile = "../Images/dogs.png";
+  const char *outputImageFile = "../Images/blurred_dogs.png";
 
   auto inputImage = util::read_image(inputImageFile, halo);
 
@@ -78,7 +72,7 @@ TEST_CASE("image_convolution_vectorized", "vectors_solution") {
 
       util::benchmark(
           [&]() {
-            myQueue.submit([&](sycl::handler& cgh) {
+            myQueue.submit([&](sycl::handler &cgh) {
               sycl::accessor inputAcc{inBufVec, cgh, sycl::read_only};
               sycl::accessor outputAcc{outBufVec, cgh, sycl::write_only};
               sycl::accessor filterAcc{filterBufVec, cgh, sycl::read_only};
@@ -111,11 +105,11 @@ TEST_CASE("image_convolution_vectorized", "vectors_solution") {
           },
           100, "image convolution (vectorized)");
     }
-  } catch (const sycl::exception& e) {
+  } catch (const sycl::exception &e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
   util::write_image(outputImage, outputImageFile);
 
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Vectors/source.cpp
+++ b/Code_Exercises/Vectors/source.cpp
@@ -8,9 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include <cassert>
+#include "../helpers.hpp"
 
 int main() {
   // Use your code from Exercise 16 to start
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Vectors/source.cpp
+++ b/Code_Exercises/Vectors/source.cpp
@@ -8,10 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
 
-TEST_CASE("image_convolution_vectorized", "vectors_source") {
+int main() {
   // Use your code from Exercise 16 to start
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/What_is_SYCL/README.md
+++ b/Code_Exercises/What_is_SYCL/README.md
@@ -118,7 +118,7 @@ make What_is_SYCL_source
 ```
 Alternatively from a terminal at the command line:
 ```sh
-icpx -fsycl -o What_is_SYCL_source -I../External/Catch2/single_include ../Code_Exercises/What_is_SYCL/source.cpp
+icpx -fsycl -o What_is_SYCL_source ../Code_Exercises/What_is_SYCL/source.cpp
 ./What_is_SYCL_source
 ```
 
@@ -136,7 +136,7 @@ make What_is_SYCL_source
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/What_is_SYCL
-/path/to/AdaptiveCpp/bin/acpp -o What_is_SYCL_source -I../../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
+/path/to/AdaptiveCpp/bin/acpp -o What_is_SYCL_source --acpp-targets="<target specification>" source.cpp
 ./What_is_SYCL_source
 ```
 

--- a/Code_Exercises/What_is_SYCL/solution.cpp
+++ b/Code_Exercises/What_is_SYCL/solution.cpp
@@ -8,7 +8,8 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
 #include <sycl/sycl.hpp>
 
 // The below tests that the header file has been included
-int main() { assert(true); }
+int main() { SYCLACADEMY_ASSERT(true); }

--- a/Code_Exercises/What_is_SYCL/solution.cpp
+++ b/Code_Exercises/What_is_SYCL/solution.cpp
@@ -8,12 +8,7 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 #include <sycl/sycl.hpp>
 
 // The below tests that the header file has been included
-TEST_CASE("empty_sycl_source_file", "compiling_with_sycl_solution") {
-  REQUIRE(true);
-}
+int main() { assert(true); }

--- a/Code_Exercises/What_is_SYCL/source.cpp
+++ b/Code_Exercises/What_is_SYCL/source.cpp
@@ -8,13 +8,7 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
-
 // Task: Include SYCL header file
 
-
 // The below tests that the header file has been included
-TEST_CASE("empty_sycl_source_file", "compiling_with_sycl_source") {
-  REQUIRE(true);
-}
+int main() {}

--- a/Code_Exercises/Work_Group_Sizes/solution.cpp
+++ b/Code_Exercises/Work_Group_Sizes/solution.cpp
@@ -11,8 +11,6 @@
 #include <algorithm>
 #include <iostream>
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
 
 #include <sycl/sycl.hpp>
 
@@ -25,7 +23,7 @@ inline constexpr util::filter_type filterType = util::filter_type::blur;
 inline constexpr int filterWidth = 11;
 inline constexpr int halo = filterWidth / 2;
 
-TEST_CASE("image_convolution_tiled", "local_memory_tiling_solution") {
+int main() {
   constexpr auto inputImageFile = "../Images/dogs.png";
   constexpr auto outputImageFile = "../Images/blurred_dogs.png";
 
@@ -125,5 +123,5 @@ TEST_CASE("image_convolution_tiled", "local_memory_tiling_solution") {
 
   util::write_image(outputImage, outputImageFile);
 
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Work_Group_Sizes/solution.cpp
+++ b/Code_Exercises/Work_Group_Sizes/solution.cpp
@@ -13,7 +13,6 @@
 #include <algorithm>
 #include <iostream>
 
-
 #include <sycl/sycl.hpp>
 
 #include <benchmark.h>
@@ -37,7 +36,7 @@ int main() {
   auto filter = util::generate_filter(util::filter_type::blur, filterWidth);
 
   try {
-    sycl::queue myQueue{sycl::gpu_selector_v};
+    sycl::queue myQueue { sycl::gpu_selector_v };
 
     std::cout << "Running on "
               << myQueue.get_device().get_info<sycl::info::device::name>()
@@ -62,9 +61,9 @@ int main() {
     auto scratchpadRange = localRange + sycl::range(halo * 2, halo * 2);
 
     {
-      auto inBuf = sycl::buffer{inputImage.data(), inBufRange};
-      auto outBuf = sycl::buffer<float, 2>{outBufRange};
-      auto filterBuf = sycl::buffer{filter.data(), filterRange};
+      auto inBuf = sycl::buffer { inputImage.data(), inBufRange };
+      auto outBuf = sycl::buffer<float, 2> { outBufRange };
+      auto filterBuf = sycl::buffer { filter.data(), filterRange };
       outBuf.set_final_data(outputImage.data());
 
       auto inBufVec = inBuf.reinterpret<sycl::float4>(inBufRange /
@@ -76,13 +75,13 @@ int main() {
 
       util::benchmark(
           [&] {
-            myQueue.submit([&](sycl::handler &cgh) {
-              sycl::accessor inputAcc{inBufVec, cgh, sycl::read_only};
-              sycl::accessor outputAcc{outBufVec, cgh, sycl::write_only};
-              sycl::accessor filterAcc{filterBufVec, cgh, sycl::read_only};
+            myQueue.submit([&](sycl::handler& cgh) {
+              sycl::accessor inputAcc { inBufVec, cgh, sycl::read_only };
+              sycl::accessor outputAcc { outBufVec, cgh, sycl::write_only };
+              sycl::accessor filterAcc { filterBufVec, cgh, sycl::read_only };
 
-              auto scratchpad = sycl::local_accessor<sycl::float4, 2>(
-                  scratchpadRange, cgh);
+              auto scratchpad =
+                  sycl::local_accessor<sycl::float4, 2>(scratchpadRange, cgh);
 
               cgh.parallel_for<image_convolution>(
                   ndRange, [=](sycl::nd_item<2> item) {
@@ -102,7 +101,7 @@ int main() {
 
                     sycl::group_barrier(item.get_group());
 
-                    auto sum = sycl::float4{0.0f, 0.0f, 0.0f, 0.0f};
+                    auto sum = sycl::float4 { 0.0f, 0.0f, 0.0f, 0.0f };
 
                     for (int r = 0; r < filterWidth; ++r) {
                       for (int c = 0; c < filterWidth; ++c) {

--- a/Code_Exercises/Work_Group_Sizes/solution.cpp
+++ b/Code_Exercises/Work_Group_Sizes/solution.cpp
@@ -8,6 +8,8 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
+#include "../helpers.hpp"
+
 #include <algorithm>
 #include <iostream>
 
@@ -123,5 +125,5 @@ int main() {
 
   util::write_image(outputImage, outputImageFile);
 
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Work_Group_Sizes/source.cpp
+++ b/Code_Exercises/Work_Group_Sizes/source.cpp
@@ -8,10 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#define CATCH_CONFIG_MAIN
-#include <catch2/catch.hpp>
+#include <cassert>
 
-TEST_CASE("image_convolution_work_group_sizes", "work_group_sizes_source") {
+int main() {
   // Use your code from Exercise 18 to start
-  REQUIRE(true);
+  assert(true);
 }

--- a/Code_Exercises/Work_Group_Sizes/source.cpp
+++ b/Code_Exercises/Work_Group_Sizes/source.cpp
@@ -8,9 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include <cassert>
+#include "../helpers.hpp"
 
 int main() {
   // Use your code from Exercise 18 to start
-  assert(true);
+  SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/adaptivecpp.md
+++ b/Code_Exercises/adaptivecpp.md
@@ -19,6 +19,6 @@ make <exercise name>_source
 alternatively, without CMake:
 ```sh
 cd Code_Exercises/<Exercise directory>
-/path/to/adaptivecpp/bin/acpp -o sycl-<exercise name>_source -I../External/Catch2/single_include --acpp-targets="<target specification>" source.cpp
+/path/to/adaptivecpp/bin/acpp -o sycl-<exercise name>_source --acpp-targets="<target specification>" source.cpp
 ./sycl-<exercise name>_source
 ```

--- a/Code_Exercises/devcloud.md
+++ b/Code_Exercises/devcloud.md
@@ -15,7 +15,7 @@ and execute:
 
 Alternatively from a terminal at the command line:
 ```sh
-icpx -fsycl -o <exercise name>_source -I../External/Catch2/single_include ../Code_Exercises/<Exercise directory>/source.cpp
+icpx -fsycl -o <exercise name>_source ../Code_Exercises/<Exercise directory>/source.cpp
 ```
 
 In Intel DevCloud, to run computational applications, you will submit jobs to a queue for execution on compute nodes,

--- a/Code_Exercises/devcloudJupyter.md
+++ b/Code_Exercises/devcloudJupyter.md
@@ -15,7 +15,7 @@ and execute:
 
 Alternatively from a terminal at the command line:
 ```sh
-icpx -fsycl -o <exercise name>_source -I../../External/Catch2/single_include ../Code_Exercises/<Exercise directory>/source.cpp
+icpx -fsycl -o <exercise name>_source ../Code_Exercises/<Exercise directory>/source.cpp
 ```
 
 In Intel DevCloud, to run computational applications, you will submit jobs to a queue for execution on compute nodes,

--- a/Code_Exercises/dpcpp.md
+++ b/Code_Exercises/dpcpp.md
@@ -14,5 +14,5 @@ make <exercise name>_source
 
 Alternatively from a terminal at the command line:
 ```sh
-icpx -fsycl -o <exercise name>_source -I../External/Catch2/single_include ../Code_Exercises/<Exercise directory>/source.cpp
+icpx -fsycl -o <exercise name>_source ../Code_Exercises/<Exercise directory>/source.cpp
 ```

--- a/Code_Exercises/helpers.hpp
+++ b/Code_Exercises/helpers.hpp
@@ -4,8 +4,6 @@
 #include <iostream>
 
 #define SYCLACADEMY_ASSERT(cond)                                               \
-  if (!(cond)) {                                                               \
-    std::cerr << "Failure in " << __BASE_FILE__ << ":" << __FUNCTION__         \
-              << std::endl;                                                    \
-    std::abort();                                                              \
-  }
+  (static_cast<bool>(cond)                                                     \
+       ? void(0)                                                               \
+       : __assert_fail(#expr, __FILE__, __LINE__, __ASSERT_FUNCTION))

--- a/Code_Exercises/helpers.hpp
+++ b/Code_Exercises/helpers.hpp
@@ -1,9 +1,25 @@
+/*
+ SYCL Academy (c)
+
+ SYCL Academy is licensed under a Creative Commons
+ Attribution-ShareAlike 4.0 International License.
+
+ You should have received a copy of the license along with this
+ work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
+*/
+
 #pragma once
 
 #include <cstddef> // for size_t
-#include <iostream>
+
+#ifndef __SYCL_DEVICE_ONLY__
+extern "C" void __assert_fail(const char* __assertion, const char* __file,
+                              unsigned int __line, const char* __function);
 
 #define SYCLACADEMY_ASSERT(cond)                                               \
   (static_cast<bool>(cond)                                                     \
        ? void(0)                                                               \
-       : __assert_fail(#expr, __FILE__, __LINE__, __ASSERT_FUNCTION))
+       : __assert_fail(#cond, __FILE__, __LINE__, __FUNCTION__))
+#else
+#define SYCLACADEMY_ASSERT(cond) void(0);
+#endif

--- a/Code_Exercises/helpers.hpp
+++ b/Code_Exercises/helpers.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <cstddef> // for size_t
+#include <iostream>
+
+#define SYCLACADEMY_ASSERT(cond)                                               \
+  if (!(cond)) {                                                               \
+    std::cerr << "Failure in " << __FUNCTION__ << std::endl;                   \
+    std::abort();                                                              \
+  }

--- a/Code_Exercises/helpers.hpp
+++ b/Code_Exercises/helpers.hpp
@@ -5,6 +5,7 @@
 
 #define SYCLACADEMY_ASSERT(cond)                                               \
   if (!(cond)) {                                                               \
-    std::cerr << "Failure in " << __FUNCTION__ << std::endl;                   \
+    std::cerr << "Failure in " << __BASE_FILE__ << ":" << __FUNCTION__         \
+              << std::endl;                                                    \
     std::abort();                                                              \
   }

--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Where `<dpc++_install_root>` is wherever the `oneAPI` directory is installed.
 
 Once that's done you can invoke the DPC++ compiler as follows:
 
-`icpx -fsycl -I<syclacademy_root>/External/Catch2/single_include -o a.out source.cpp`
+`icpx -fsycl -o a.out source.cpp`
 
 Where `<syclacademy_root>` is the path to the root directory of where you cloned
 this repository. Note that on Windows you need to add the option /EHsc to avoid exception handling error.


### PR DESCRIPTION
Simplify by removing catch2 dependencies. This makes code exercises easier to understand and reduces build times.

Also add a `.clang-format` based on the SYCL-Docs clang format style.