### PR TITLE
Update SYCLACADEMY_ASSERT

### DIFF
--- a/Code_Exercises/helpers.hpp
+++ b/Code_Exercises/helpers.hpp
@@ -13,13 +13,14 @@
 #include <cstddef> // for size_t
 
 #ifndef __SYCL_DEVICE_ONLY__
-extern "C" void __assert_fail(const char* __assertion, const char* __file,
-                              unsigned int __line, const char* __function);
-
+#include <cstdio>  // fprintf
+#include <cstdlib> // abort
 #define SYCLACADEMY_ASSERT(cond)                                               \
-  (static_cast<bool>(cond)                                                     \
-       ? void(0)                                                               \
-       : __assert_fail(#cond, __FILE__, __LINE__, __FUNCTION__))
+  if (!(cond)) {                                                               \
+    std::fprintf(stderr, "%s failed in %s:%d:%s\nExiting\n", #cond,            \
+                 __BASE_FILE__, __LINE__, __FUNCTION__);                       \
+    std::abort();                                                              \
+  }
 #else
 #define SYCLACADEMY_ASSERT(cond) void(0);
 #endif


### PR DESCRIPTION
Don't use `__assert_fail`, this is likely to break on different systems.

Fixes https://github.com/codeplaysoftware/syclacademy/pull/368