### PR TITLE
Remove all remaining references to exercise numbers

### DIFF
--- a/Code_Exercises/Advanced_Data_Flow/CMakeLists.txt
+++ b/Code_Exercises/Advanced_Data_Flow/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_12_temporary_data
 add_sycl_executable(Advanced_Data_Flow source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(Advanced_Data_Flow solution)

--- a/Code_Exercises/Advanced_Data_Flow/README.md
+++ b/Code_Exercises/Advanced_Data_Flow/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 12: Temporary Data
+## Temporary Data
 ---
 
 In this exercise you will learn how to use temporary data and avoid unnecessary

--- a/Code_Exercises/Asynchronous_Execution/CMakeLists.txt
+++ b/Code_Exercises/Asynchronous_Execution/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_09_synchronization
 add_sycl_executable(Asynchronous_Execution source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(Asynchronous_Execution solution)

--- a/Code_Exercises/Asynchronous_Execution/README.md
+++ b/Code_Exercises/Asynchronous_Execution/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 9: Asynchronous_Execution
+## Asynchronous_Execution
 ---
 
 In this exercise you will learn how to use different techniques for
@@ -11,8 +11,9 @@ synchronizing commands and data.
 ### 1.) Waiting on events
 
 Take a look at the vector add applications using the buffer/accessor model in
-exercise 6 and the USM model in exercise 8, and familiarize yourself with how
-they call `wait` on returned `event`s to synchronize the completion of the work.
+the "Data Parallelism" exercise and the USM model in the "Using USM" exercise,
+and familiarize yourself with how they call `wait` on returned `event`s to
+synchronize the completion of the work.
 
 ### 2.) Waiting on queues
 
@@ -22,7 +23,8 @@ synchronize instead.
 ### 3.) Buffer destruction
 
 Take a look at the vector add application using the buffer/accessor mode in
-exercise 6 and how it synchronizes on the destruction of the `buffer`s. 
+the "Data Parallelism" exercise and how it synchronizes on the destruction of
+the `buffer`s.
 
 ### 4.) Copy back
 

--- a/Code_Exercises/Asynchronous_Execution/source.cpp
+++ b/Code_Exercises/Asynchronous_Execution/source.cpp
@@ -47,12 +47,12 @@
 #include "../helpers.hpp"
 
 void test_usm() {
-  // Use your code from Exercise 3 to start
+  // Use your code from the "Data Parallelism" exercise to start
   SYCLACADEMY_ASSERT(true);
 }
 
 void test_buffer() {
-  // Use your code from Exercise 3 to start
+  // Use your code from the "Data Parallelism" exercise to start
   SYCLACADEMY_ASSERT(true);
 }
 

--- a/Code_Exercises/Coalesced_Global_Memory/CMakeLists.txt
+++ b/Code_Exercises/Coalesced_Global_Memory/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_16_coalesced_global_memory
 add_sycl_executable(Coalesced_Global_Memory source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(Coalesced_Global_Memory solution)

--- a/Code_Exercises/Coalesced_Global_Memory/README.md
+++ b/Code_Exercises/Coalesced_Global_Memory/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 16: Coalesced Global Memory
+## Coalesced Global Memory
 ---
 
 In this exercise you will learn how to apply row-major and column-major when

--- a/Code_Exercises/Coalesced_Global_Memory/source.cpp
+++ b/Code_Exercises/Coalesced_Global_Memory/source.cpp
@@ -11,6 +11,6 @@
 #include "../helpers.hpp"
 
 int main() {
-  // Use your code from Exercise 15 to start
+  // Use your code from the "Image Convolution" exercise to start
   SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Data_Parallelism/CMakeLists.txt
+++ b/Code_Exercises/Data_Parallelism/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_06_vector_add
 add_sycl_executable(Data_Parallelism source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(Data_Parallelism solution)

--- a/Code_Exercises/Data_Parallelism/README.md
+++ b/Code_Exercises/Data_Parallelism/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 6: Vector Add
+## Vector Add
 
 ---
 

--- a/Code_Exercises/Data_and_Dependencies/CMakeLists.txt
+++ b/Code_Exercises/Data_and_Dependencies/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_10_managing_dependencies
 add_sycl_executable(Data_and_Dependencies source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(Data_and_Dependencies solution)

--- a/Code_Exercises/Data_and_Dependencies/README.md
+++ b/Code_Exercises/Data_and_Dependencies/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 10: Managing Dependencies
+## Managing Dependencies
 ---
 
 In this exercise you will learn how to create a data dependency data flow graph

--- a/Code_Exercises/Device_Discovery/CMakeLists.txt
+++ b/Code_Exercises/Device_Discovery/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_05_device_selection
 add_sycl_executable(Device_Discovery source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(Device_Discovery solution)

--- a/Code_Exercises/Device_Discovery/README.md
+++ b/Code_Exercises/Device_Discovery/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 5: Device Selection
+## Device Selection
 
 ---
 

--- a/Code_Exercises/Enqueueing_a_Kernel/CMakeLists.txt
+++ b/Code_Exercises/Enqueueing_a_Kernel/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_02_hello_world
 add_sycl_executable(Enqueueing_a_Kernel source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(Enqueueing_a_Kernel solution)

--- a/Code_Exercises/Enqueueing_a_Kernel/README.md
+++ b/Code_Exercises/Enqueueing_a_Kernel/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 2: Hello World
+## Hello World
 
 ---
 

--- a/Code_Exercises/Functors/README.md
+++ b/Code_Exercises/Functors/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 22: Functors
+## Functors
 ---
 
 In this exercise you will learn how to use `functors` instead of lambda

--- a/Code_Exercises/Handling_Errors/CMakeLists.txt
+++ b/Code_Exercises/Handling_Errors/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_04_handling_errors
 add_sycl_executable(Handling_Errors source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(Handling_Errors solution)

--- a/Code_Exercises/Handling_Errors/README.md
+++ b/Code_Exercises/Handling_Errors/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 4: Handling Errors
+## Handling Errors
 
 ---
 

--- a/Code_Exercises/Image_Convolution/CMakeLists.txt
+++ b/Code_Exercises/Image_Convolution/CMakeLists.txt
@@ -8,5 +8,4 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_15_image_convolution
 add_sycl_executable(Image_Convolution reference)

--- a/Code_Exercises/Image_Convolution/README.md
+++ b/Code_Exercises/Image_Convolution/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 15: Image Convolution
+## Image Convolution
 ---
 
 In this exercise there is no task, simply familiarize yourself with the image

--- a/Code_Exercises/In_Order_Queue/CMakeLists.txt
+++ b/Code_Exercises/In_Order_Queue/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_11_in_order_queue
 add_sycl_executable(In_Order_Queue source_vector_add)
 add_sycl_executable(In_Order_Queue source_queue_benchmarking)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)

--- a/Code_Exercises/In_Order_Queue/README.md
+++ b/Code_Exercises/In_Order_Queue/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 11: In Order Queue
+## In Order Queue
 ---
 
 In this exercise you will learn how to create a fixed data flow using an
@@ -20,21 +20,24 @@ Performance is poor as kernels cannot execute concurrently. Your goal is to impr
 
 ### 1.) In order queue with buffer/accessor model
 
-Using the application from exercise 10 which uses the buffer/accessor model
-convert the `queue` to in-order using the `property::queue::in_order` property,
-converting the data flow graph to a fixed execution order.
+Using the application from the "Data and Dependencies" exercise which uses the
+buffer/accessor model convert the `queue` to in-order using the
+`property::queue::in_order` property, converting the data flow graph to a fixed
+execution order.
 
 Feel free to have the kernel functions execute in any order you like providing
-the necessary dependencies described in exercise 10 are still met.
+the necessary dependencies described in the "Data and Dependencies" exercise are
+still met.
 
 ### 2.) In order queue with USM model
 
-Now do the same using the application from exercise 10 which uses the USM model,
-again converting the `queue` to in-order, converting the data flow graph to a
-fixed execution order.
+Now do the same using the application from the "Data and Dependencies" exercise
+which uses the USM model, again converting the `queue` to in-order, converting
+the data flow graph to a fixed execution order.
 
 Again feel free to have the kernel functions execute in any order you like
-providing the necessary dependencies described in exercise 10 are still met.
+providing the necessary dependencies described in the "Data and Dependencies"
+exercise are still met.
 
 Note that in the USM model when using an in-order `queue` it is no longer
 necessary to chain commands using `event`s.

--- a/Code_Exercises/In_Order_Queue/source_vector_add.cpp
+++ b/Code_Exercises/In_Order_Queue/source_vector_add.cpp
@@ -58,6 +58,6 @@
 #include "../helpers.hpp"
 
 int main() {
-  // Use the Exercise 10 solution to start
+  // Use the "Data and Dependencies" exercise solution to start
   SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Introduction_to_USM/CMakeLists.txt
+++ b/Code_Exercises/Introduction_to_USM/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_07_usm_selector
 add_sycl_executable(Introduction_to_USM source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(Introduction_to_USM solution)

--- a/Code_Exercises/Introduction_to_USM/README.md
+++ b/Code_Exercises/Introduction_to_USM/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 7: USM Selector
+## USM Selector
 ---
 
 In this exercise you will learn how to find a suitable device for using the USM data management model.
@@ -9,7 +9,7 @@ In this exercise you will learn how to find a suitable device for using the USM 
 
 ### 1.) Create a device selector
 
-Create a custom device selector as you did in exercise 5.
+Create a custom device selector as you did in the "Device Discovery" exercise.
 
 ### 2.) Check for USM support
 

--- a/Code_Exercises/Local_Memory_Tiling/CMakeLists.txt
+++ b/Code_Exercises/Local_Memory_Tiling/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_18_local_memory_tiling
 add_sycl_executable(Local_Memory_Tiling source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(Local_Memory_Tiling solution)

--- a/Code_Exercises/Local_Memory_Tiling/README.md
+++ b/Code_Exercises/Local_Memory_Tiling/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 18: Local Memory Tiling
+## Local Memory Tiling
 ---
 
 In this exercise you will learn how to cache global memory into local memory in

--- a/Code_Exercises/Local_Memory_Tiling/source.cpp
+++ b/Code_Exercises/Local_Memory_Tiling/source.cpp
@@ -11,6 +11,6 @@
 #include "../helpers.hpp"
 
 int main() {
-  // Use your code from Exercise 17 to start
+  // Use your code from the "Vectors" exercise to start
   SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Managing_Data/CMakeLists.txt
+++ b/Code_Exercises/Managing_Data/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_03_scalar_add
 add_sycl_executable(Managing_Data source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(Managing_Data solution)

--- a/Code_Exercises/Managing_Data/README.md
+++ b/Code_Exercises/Managing_Data/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 3: Scalar Add
+## Scalar Add
 
 ---
 

--- a/Code_Exercises/Matrix_Transpose/README.md
+++ b/Code_Exercises/Matrix_Transpose/README.md
@@ -1,4 +1,6 @@
-## Exercise: Local Memory Matrix Transpose
+# SYCL Academy
+
+## Local Memory Matrix Transpose
 ---
 
 This exercise uses GPU specific features in order to gain good GPU performance.

--- a/Code_Exercises/More_SYCL_Features/CMakeLists.txt
+++ b/Code_Exercises/More_SYCL_Features/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_06_vector_add
 add_sycl_executable(More_SYCL_Features reduce_naive)
 add_sycl_executable(More_SYCL_Features reduce_atomic)
 add_sycl_executable(More_SYCL_Features reduce_group_algorithms)

--- a/Code_Exercises/Multiple_Devices/CMakeLists.txt
+++ b/Code_Exercises/Multiple_Devices/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_13_load_balancing
 add_sycl_executable(Multiple_Devices source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(Multiple_Devices solution)

--- a/Code_Exercises/Multiple_Devices/README.md
+++ b/Code_Exercises/Multiple_Devices/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 13: Load Balancing
+## Load Balancing
 
 ---
 
@@ -19,9 +19,10 @@ Then create a `queue` for each of the two devices.
 
 ### 3. ) Split a task across the two queues
 
-Using either the application from exercise 6 using the buffer/accessor model or
-the application from exercise 8 with the USM model create an application where
-the work is distributed across two devices using the two `queue`s you created.
+Using either the application from the "Data Parallelism" exercise with the
+buffer/accessor model or the application from the "Using USM" exercise with the
+USM model, create an application where the work is distributed across two
+devices using the two `queue`s you created.
 
 Remember to create separate `buffer`s for the separate parts of the data being
 computed.

--- a/Code_Exercises/ND_Range_Kernel/CMakeLists.txt
+++ b/Code_Exercises/ND_Range_Kernel/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_14_nd_range_kernel
 add_sycl_executable(ND_Range_Kernel source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(ND_Range_Kernel solution)

--- a/Code_Exercises/ND_Range_Kernel/README.md
+++ b/Code_Exercises/ND_Range_Kernel/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 14: ND Range Kernel
+## ND Range Kernel
 ---
 
 In this exercise you will learn how to enqueue ND range kernel functions.

--- a/Code_Exercises/OneMKL_gemm/CMakeLists.txt
+++ b/Code_Exercises/OneMKL_gemm/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_11_onemkl_dgemm
 add_sycl_executable(OneMKL_gemm source_onemkl_usm_gemm)
 add_sycl_executable(OneMKL_gemm source_onemkl_buffer_gemm)
 

--- a/Code_Exercises/OneMKL_gemm/README.md
+++ b/Code_Exercises/OneMKL_gemm/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 11: Use of oneMKL library
+## Use of oneMKL library
 ---
 
 In this exercise you will learn how to make use of APIs from oneMKL Interfaces library.

--- a/Code_Exercises/Using_USM/CMakeLists.txt
+++ b/Code_Exercises/Using_USM/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_08_usm_vector_add
 add_sycl_executable(USM_Data_Parallelism source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(USM_Data_Parallelism solution)

--- a/Code_Exercises/Using_USM/README.md
+++ b/Code_Exercises/Using_USM/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 8: USM Vector Add
+## USM Vector Add
 ---
 
 In this exercise you will learn how to use the USM API to write a SYCL
@@ -15,8 +15,8 @@ using the buffer/accessor model.
 
 ### 2.) Create a queue
 
-Create a `queue` using the USM device selector from exercise 7, remember to
-handle errors.
+Create a `queue` using the USM device selector from the "Introduction to USM"
+exercise, remember to handle errors.
 
 ### 3.) Allocate device memory
 
@@ -37,7 +37,7 @@ remember to call `wait` on the `event` that is returned.
 ### 5.) Define the kernel function
 
 Now you can define the kernel function itself, which is largely the same as in
-exercise 7.
+the "Data Parallelism" exercise.
 
 This can be done differently from the buffer/accessor model, by calling the
 shortcut member function `parallel_for` on the `queue` rather than creating a

--- a/Code_Exercises/Vectors/CMakeLists.txt
+++ b/Code_Exercises/Vectors/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_17_vectors
 add_sycl_executable(Vectors source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(Vectors solution)

--- a/Code_Exercises/Vectors/README.md
+++ b/Code_Exercises/Vectors/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 17: Vectors
+## Vectors
 ---
 
 In this exercise you will learn how to use `vec` to explicitly vectorized your

--- a/Code_Exercises/Vectors/source.cpp
+++ b/Code_Exercises/Vectors/source.cpp
@@ -11,6 +11,7 @@
 #include "../helpers.hpp"
 
 int main() {
-  // Use your code from Exercise 16 to start
+  // Use your code from the "Coalesced Global Memory" or "Image Convolution"
+  // exercises to start
   SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/What_is_SYCL/CMakeLists.txt
+++ b/Code_Exercises/What_is_SYCL/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_01_compiling_with_sycl
 add_sycl_executable(What_is_SYCL source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(What_is_SYCL solution)

--- a/Code_Exercises/What_is_SYCL/README.md
+++ b/Code_Exercises/What_is_SYCL/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 1: Compiling with SYCL
+## Compiling with SYCL
 
 ---
 

--- a/Code_Exercises/Work_Group_Sizes/CMakeLists.txt
+++ b/Code_Exercises/Work_Group_Sizes/CMakeLists.txt
@@ -8,7 +8,6 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
-# Exercise exercise_19_work_group_sizes
 add_sycl_executable(Work_Group_Sizes source)
 if(SYCL_ACADEMY_ENABLE_SOLUTIONS)
   add_sycl_executable(Work_Group_Sizes solution)

--- a/Code_Exercises/Work_Group_Sizes/README.md
+++ b/Code_Exercises/Work_Group_Sizes/README.md
@@ -1,6 +1,6 @@
 # SYCL Academy
 
-## Exercise 19: Work-Group Sizes
+## Work-Group Sizes
 ---
 
 In this exercise you will learn how to use different work-group sizes in order

--- a/Code_Exercises/Work_Group_Sizes/source.cpp
+++ b/Code_Exercises/Work_Group_Sizes/source.cpp
@@ -11,6 +11,6 @@
 #include "../helpers.hpp"
 
 int main() {
-  // Use your code from Exercise 18 to start
+  // Use your code from the "Local Memory Tiling" exercise to start
   SYCLACADEMY_ASSERT(true);
 }

--- a/Lesson_Materials/Handling_Errors/index.html
+++ b/Lesson_Materials/Handling_Errors/index.html
@@ -432,7 +432,7 @@ int main() {
 						#### Exercise
 					</div>
 					<div class="container" data-markdown>
-						Code_Exercises/Exercise_4_Handling_Errors/source
+						Code_Exercises/Handling_Errors/source
 					</div>
 					<div class="container" data-markdown>
 						Add error handling to a SYCL application for both synchronous and asynchronous errors.


### PR DESCRIPTION
We removed exercise numbers from directory names some time ago, but missed several references to the numbers in the `Code_Exercises` README files and a few `source.cpp` files. To fix this:
* remove the numbering from the title line in each README 
* replace references to a number with the full name of an exercise, for example replace `exercise 6` with `the "Data Parallelism" exercise`
* remove a comment with the exercise name from each CMakeLists.txt in Code_Exercises
* fix the path name in `Lesson_Materials/Handling_Errors/index.html`

This is not a blind search and replace change. Some references were pointing to the wrong exercise, so they are updated to make more sense. For example, `Using_USM/README.md` was referring to a kernel function in exercise 7 which had no kernels (the correct one would've been exercise 6).