### PR TITLE
Change clang-format style and add GitHub workflow

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,8 +1,18 @@
-Language: Cpp
-BasedOnStyle: LLVM
-AccessModifierOffset: -1
-BreakInheritanceList: BeforeComma
-BreakConstructorInitializers: BeforeComma
-Cpp11BracedListStyle: false
-PointerAlignment: Left
-SpaceBeforeCpp11BracedList: true
+BasedOnStyle: Google
+IncludeCategories:
+  - Regex:           '^<sycl/.*>$'
+    Priority:        3
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '^<.*'
+    Priority:        2
+    SortPriority:    0
+    CaseSensitive:   false
+  - Regex:           '.*'
+    Priority:        4
+    SortPriority:    0
+    CaseSensitive:   false

--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -1,0 +1,17 @@
+name: clang-format check
+on: [push, pull_request]
+permissions:
+  contents: read
+jobs:
+  clang-format:
+    name: clang-format check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: clang-format
+      uses: jidicula/clang-format-action@v4.14.0
+      with:
+        clang-format-version: '19'
+        check-path: 'Code_Exercises'
+        fallback-style: 'Google'
+        include-regex: '^.*\.(((c|C)(c|pp|xx|\+\+)?$)|((h|H)h?(pp|xx|\+\+)?$))$'

--- a/Code_Exercises/Advanced_Data_Flow/solution.cpp
+++ b/Code_Exercises/Advanced_Data_Flow/solution.cpp
@@ -8,8 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 class kernel_a_1;
 class kernel_b_1;
@@ -18,8 +19,7 @@ class kernel_b_2;
 
 int usm_selector(const sycl::device& dev) {
   if (dev.has(sycl::aspect::usm_device_allocations)) {
-    if (dev.has(sycl::aspect::gpu))
-      return 2;
+    if (dev.has(sycl::aspect::gpu)) return 2;
     return 1;
   }
   return -1;
@@ -35,31 +35,31 @@ void test_buffer() {
   }
 
   try {
-    auto gpuQueue = sycl::queue { sycl::gpu_selector_v };
+    auto gpuQueue = sycl::queue{sycl::gpu_selector_v};
 
-    auto bufIn = sycl::buffer { in, sycl::range { dataSize } };
-    auto bufInt = sycl::buffer<float> { sycl::range { dataSize } };
-    auto bufOut = sycl::buffer<float> { sycl::range { dataSize } };
+    auto bufIn = sycl::buffer{in, sycl::range{dataSize}};
+    auto bufInt = sycl::buffer<float>{sycl::range{dataSize}};
+    auto bufOut = sycl::buffer<float>{sycl::range{dataSize}};
 
     bufIn.set_final_data(nullptr);
     bufOut.set_final_data(out);
 
     gpuQueue.submit([&](sycl::handler& cgh) {
-      sycl::accessor accIn { bufIn, cgh, sycl::read_only };
-      sycl::accessor accOut { bufInt, cgh, sycl::write_only };
+      sycl::accessor accIn{bufIn, cgh, sycl::read_only};
+      sycl::accessor accOut{bufInt, cgh, sycl::write_only};
 
-      cgh.parallel_for<kernel_a_1>(
-          sycl::range { dataSize },
-          [=](sycl::id<1> idx) { accOut[idx] = accIn[idx] * 8.0f; });
+      cgh.parallel_for<kernel_a_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
+        accOut[idx] = accIn[idx] * 8.0f;
+      });
     });
 
     gpuQueue.submit([&](sycl::handler& cgh) {
-      sycl::accessor accIn { bufInt, cgh, sycl::read_only };
-      sycl::accessor accOut { bufOut, cgh, sycl::write_only };
+      sycl::accessor accIn{bufInt, cgh, sycl::read_only};
+      sycl::accessor accOut{bufOut, cgh, sycl::write_only};
 
-      cgh.parallel_for<kernel_b_1>(
-          sycl::range { dataSize },
-          [=](sycl::id<1> idx) { accOut[idx] = accIn[idx] / 2.0f; });
+      cgh.parallel_for<kernel_b_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
+        accOut[idx] = accIn[idx] / 2.0f;
+      });
     });
 
     gpuQueue.wait_and_throw();
@@ -82,7 +82,7 @@ void test_usm() {
   }
 
   try {
-    auto usmQueue = sycl::queue { usm_selector };
+    auto usmQueue = sycl::queue{usm_selector};
 
     auto devicePtrIn = sycl::malloc_device<float>(dataSize, usmQueue);
     auto devicePtrInt = sycl::malloc_device<float>(dataSize, usmQueue);
@@ -91,13 +91,13 @@ void test_usm() {
     auto e1 = usmQueue.memcpy(devicePtrIn, in, sizeof(float) * dataSize);
 
     auto e2 = usmQueue.parallel_for<kernel_a_2>(
-        sycl::range { dataSize }, e1, [=](sycl::id<1> idx) {
+        sycl::range{dataSize}, e1, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrInt[globalId] = devicePtrIn[globalId] * 8.0f;
         });
 
     auto e3 = usmQueue.parallel_for<kernel_b_2>(
-        sycl::range { dataSize }, e2, [=](sycl::id<1> idx) {
+        sycl::range{dataSize}, e2, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrOut[globalId] = devicePtrInt[globalId] / 2.0f;
         });

--- a/Code_Exercises/Asynchronous_Execution/solution.cpp
+++ b/Code_Exercises/Asynchronous_Execution/solution.cpp
@@ -8,8 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 class vector_add_1;
 class vector_add_2;
@@ -20,8 +21,7 @@ class vector_add_6;
 
 int usm_selector(const sycl::device& dev) {
   if (dev.has(sycl::aspect::usm_device_allocations)) {
-    if (dev.has(sycl::aspect::gpu))
-      return 2;
+    if (dev.has(sycl::aspect::gpu)) return 2;
     return 1;
   }
   return -1;
@@ -38,26 +38,26 @@ void test_buffer_event_wait() {
   }
 
   try {
-    auto defaultQueue = sycl::queue {};
+    auto defaultQueue = sycl::queue{};
 
-    auto bufA = sycl::buffer { a, sycl::range { dataSize } };
-    auto bufB = sycl::buffer { b, sycl::range { dataSize } };
-    auto bufR = sycl::buffer { r, sycl::range { dataSize } };
+    auto bufA = sycl::buffer{a, sycl::range{dataSize}};
+    auto bufB = sycl::buffer{b, sycl::range{dataSize}};
+    auto bufR = sycl::buffer{r, sycl::range{dataSize}};
 
     defaultQueue
         .submit([&](sycl::handler& cgh) {
-          auto accA = sycl::accessor { bufA, cgh, sycl::read_only };
-          auto accB = sycl::accessor { bufB, cgh, sycl::read_only };
-          auto accR = sycl::accessor { bufR, cgh, sycl::write_only };
+          auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
+          auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
+          auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
 
           cgh.parallel_for<vector_add_1>(
-              sycl::range { dataSize },
+              sycl::range{dataSize},
               [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
         })
-        .wait(); // Synchronize
+        .wait();  // Synchronize
 
     defaultQueue.throw_asynchronous();
-  } catch (const sycl::exception& e) { // Copy back
+  } catch (const sycl::exception& e) {  // Copy back
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
@@ -77,24 +77,24 @@ void test_buffer_queue_wait() {
   }
 
   try {
-    auto defaultQueue = sycl::queue {};
+    auto defaultQueue = sycl::queue{};
 
-    auto bufA = sycl::buffer { a, sycl::range { dataSize } };
-    auto bufB = sycl::buffer { b, sycl::range { dataSize } };
-    auto bufR = sycl::buffer { r, sycl::range { dataSize } };
+    auto bufA = sycl::buffer{a, sycl::range{dataSize}};
+    auto bufB = sycl::buffer{b, sycl::range{dataSize}};
+    auto bufR = sycl::buffer{r, sycl::range{dataSize}};
 
     defaultQueue.submit([&](sycl::handler& cgh) {
-      auto accA = sycl::accessor { bufA, cgh, sycl::read_only };
-      auto accB = sycl::accessor { bufB, cgh, sycl::read_only };
-      auto accR = sycl::accessor { bufR, cgh, sycl::write_only };
+      auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
+      auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
+      auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
 
       cgh.parallel_for<vector_add_2>(
-          sycl::range { dataSize },
+          sycl::range{dataSize},
           [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
     });
 
-    defaultQueue.wait_and_throw();     // Synchronize
-  } catch (const sycl::exception& e) { // Copy back
+    defaultQueue.wait_and_throw();      // Synchronize
+  } catch (const sycl::exception& e) {  // Copy back
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
@@ -114,23 +114,23 @@ void test_buffer_buffer_destruction() {
   }
 
   try {
-    auto defaultQueue = sycl::queue {};
+    auto defaultQueue = sycl::queue{};
 
     {
-      auto bufA = sycl::buffer { a, sycl::range { dataSize } };
-      auto bufB = sycl::buffer { b, sycl::range { dataSize } };
-      auto bufR = sycl::buffer { r, sycl::range { dataSize } };
+      auto bufA = sycl::buffer{a, sycl::range{dataSize}};
+      auto bufB = sycl::buffer{b, sycl::range{dataSize}};
+      auto bufR = sycl::buffer{r, sycl::range{dataSize}};
 
       defaultQueue.submit([&](sycl::handler& cgh) {
-        auto accA = sycl::accessor { bufA, cgh, sycl::read_only };
-        auto accB = sycl::accessor { bufB, cgh, sycl::read_only };
-        auto accR = sycl::accessor { bufR, cgh, sycl::write_only };
+        auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
+        auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
+        auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
 
         cgh.parallel_for<vector_add_3>(
-            sycl::range { dataSize },
+            sycl::range{dataSize},
             [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
       });
-    } // Synchronize and copy-back
+    }  // Synchronize and copy-back
 
     defaultQueue.throw_asynchronous();
   } catch (const sycl::exception& e) {
@@ -153,7 +153,7 @@ void test_usm_event_wait() {
   }
 
   try {
-    auto usmQueue = sycl::queue { usm_selector };
+    auto usmQueue = sycl::queue{usm_selector};
 
     auto devicePtrA = sycl::malloc_device<float>(dataSize, usmQueue);
     auto devicePtrB = sycl::malloc_device<float>(dataSize, usmQueue);
@@ -161,24 +161,24 @@ void test_usm_event_wait() {
 
     usmQueue.memcpy(devicePtrA, a,
                     sizeof(float) * dataSize)
-        .wait(); // Synchronize
+        .wait();  // Synchronize
     usmQueue.memcpy(devicePtrB, b,
                     sizeof(float) * dataSize)
-        .wait(); // Synchronize
+        .wait();  // Synchronize
 
     usmQueue
-        .parallel_for<vector_add_4>(sycl::range { dataSize },
+        .parallel_for<vector_add_4>(sycl::range{dataSize},
                                     [=](sycl::id<1> idx) {
                                       auto globalId = idx[0];
                                       devicePtrR[globalId] =
                                           devicePtrA[globalId] +
                                           devicePtrB[globalId];
                                     })
-        .wait(); // Synchronize
+        .wait();  // Synchronize
 
     usmQueue.memcpy(r, devicePtrR,
                     sizeof(float) * dataSize)
-        .wait(); // Synchronize and copy-back
+        .wait();  // Synchronize and copy-back
 
     sycl::free(devicePtrA, usmQueue);
     sycl::free(devicePtrB, usmQueue);
@@ -205,7 +205,7 @@ void test_usm_queue_wait() {
   }
 
   try {
-    auto usmQueue = sycl::queue { usm_selector };
+    auto usmQueue = sycl::queue{usm_selector};
 
     auto devicePtrA = sycl::malloc_device<float>(dataSize, usmQueue);
     auto devicePtrB = sycl::malloc_device<float>(dataSize, usmQueue);
@@ -214,21 +214,21 @@ void test_usm_queue_wait() {
     usmQueue.memcpy(devicePtrA, a, sizeof(float) * dataSize);
     usmQueue.memcpy(devicePtrB, b, sizeof(float) * dataSize);
 
-    usmQueue.wait(); // Synchronize
+    usmQueue.wait();  // Synchronize
 
     usmQueue.parallel_for<vector_add_5>(
-        sycl::range { dataSize }, [=](sycl::id<1> idx) {
+        sycl::range{dataSize}, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrR[globalId] = devicePtrA[globalId] + devicePtrB[globalId];
         });
 
-    usmQueue.wait(); // Synchronize
+    usmQueue.wait();  // Synchronize
 
     usmQueue.memcpy(r, devicePtrR,
                     sizeof(float) * dataSize)
-        .wait(); // Copy-back
+        .wait();  // Copy-back
 
-    usmQueue.wait(); // Synchronize
+    usmQueue.wait();  // Synchronize
 
     sycl::free(devicePtrA, usmQueue);
     sycl::free(devicePtrB, usmQueue);
@@ -255,34 +255,34 @@ void test_buffer_host_accessor() {
   }
 
   try {
-    auto defaultQueue = sycl::queue {};
+    auto defaultQueue = sycl::queue{};
 
     {
-      auto bufA = sycl::buffer { a, sycl::range { dataSize } };
-      auto bufB = sycl::buffer { b, sycl::range { dataSize } };
-      auto bufR = sycl::buffer { r, sycl::range { dataSize } };
+      auto bufA = sycl::buffer{a, sycl::range{dataSize}};
+      auto bufB = sycl::buffer{b, sycl::range{dataSize}};
+      auto bufR = sycl::buffer{r, sycl::range{dataSize}};
 
       defaultQueue.submit([&](sycl::handler& cgh) {
-        auto accA = sycl::accessor { bufA, cgh, sycl::read_only };
-        auto accB = sycl::accessor { bufB, cgh, sycl::read_only };
-        auto accR = sycl::accessor { bufR, cgh, sycl::write_only };
+        auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
+        auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
+        auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
 
         cgh.parallel_for<vector_add_6>(
-            sycl::range { dataSize },
+            sycl::range{dataSize},
             [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
       });
 
-      defaultQueue.wait(); // Synchronize
+      defaultQueue.wait();  // Synchronize
 
       {
-        auto hostAccR = bufR.get_host_access(sycl::read_only); // Copy-to-host
+        auto hostAccR = bufR.get_host_access(sycl::read_only);  // Copy-to-host
 
         for (int i = 0; i < dataSize; ++i) {
           SYCLACADEMY_ASSERT(hostAccR[i] == i * 2);
         }
       }
 
-    } // Copy-back
+    }  // Copy-back
 
     defaultQueue.throw_asynchronous();
   } catch (const sycl::exception& e) {

--- a/Code_Exercises/Coalesced_Global_Memory/solution.cpp
+++ b/Code_Exercises/Coalesced_Global_Memory/solution.cpp
@@ -8,15 +8,15 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
+#include <benchmark.h>
+#include <image_conv.h>
 
 #include <algorithm>
 #include <iostream>
 
 #include <sycl/sycl.hpp>
 
-#include <benchmark.h>
-#include <image_conv.h>
+#include "../helpers.hpp"
 
 class image_convolution;
 
@@ -36,7 +36,7 @@ int main() {
   auto filter = util::generate_filter(util::filter_type::blur, filterWidth);
 
   try {
-    sycl::queue myQueue { sycl::gpu_selector_v };
+    sycl::queue myQueue{sycl::gpu_selector_v};
 
     std::cout << "Running on "
               << myQueue.get_device().get_info<sycl::info::device::name>()
@@ -60,17 +60,17 @@ int main() {
     auto filterRange = filterWidth * sycl::range(1, channels);
 
     {
-      auto inBuf = sycl::buffer { inputImage.data(), inBufRange };
-      auto outBuf = sycl::buffer<float, 2> { outBufRange };
-      auto filterBuf = sycl::buffer { filter.data(), filterRange };
+      auto inBuf = sycl::buffer{inputImage.data(), inBufRange};
+      auto outBuf = sycl::buffer<float, 2>{outBufRange};
+      auto filterBuf = sycl::buffer{filter.data(), filterRange};
       outBuf.set_final_data(outputImage.data());
 
       util::benchmark(
           [&]() {
             myQueue.submit([&](sycl::handler& cgh) {
-              sycl::accessor inputAcc { inBuf, cgh, sycl::read_only };
-              sycl::accessor outputAcc { outBuf, cgh, sycl::write_only };
-              sycl::accessor filterAcc { filterBuf, cgh, sycl::read_only };
+              sycl::accessor inputAcc{inBuf, cgh, sycl::read_only};
+              sycl::accessor outputAcc{outBuf, cgh, sycl::write_only};
+              sycl::accessor filterAcc{filterBuf, cgh, sycl::read_only};
 
               cgh.parallel_for<image_convolution>(
                   ndRange, [=](sycl::nd_item<2> item) {
@@ -81,7 +81,7 @@ int main() {
                     auto src = (globalId + haloOffset) * channelsStride;
                     auto dest = globalId * channelsStride;
 
-                    float sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+                    float sum[4] = {0.0f, 0.0f, 0.0f, 0.0f};
 
                     for (int r = 0; r < filterWidth; ++r) {
                       for (int c = 0; c < filterWidth; ++c) {
@@ -99,7 +99,7 @@ int main() {
                     }
 
                     for (size_t i = 0; i < 4; ++i) {
-                      outputAcc[dest + sycl::id { 0, i }] = sum[i];
+                      outputAcc[dest + sycl::id{0, i}] = sum[i];
                     }
                   });
             });

--- a/Code_Exercises/Data_Parallelism/solution.cpp
+++ b/Code_Exercises/Data_Parallelism/solution.cpp
@@ -8,8 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 class vector_add;
 
@@ -24,20 +25,20 @@ int main() {
   }
 
   try {
-    auto defaultQueue = sycl::queue {};
+    auto defaultQueue = sycl::queue{};
 
-    auto bufA = sycl::buffer { a, sycl::range { dataSize } };
-    auto bufB = sycl::buffer { b, sycl::range { dataSize } };
-    auto bufR = sycl::buffer { r, sycl::range { dataSize } };
+    auto bufA = sycl::buffer{a, sycl::range{dataSize}};
+    auto bufB = sycl::buffer{b, sycl::range{dataSize}};
+    auto bufR = sycl::buffer{r, sycl::range{dataSize}};
 
     defaultQueue
         .submit([&](sycl::handler& cgh) {
-          sycl::accessor accA { bufA, cgh, sycl::read_only };
-          sycl::accessor accB { bufB, cgh, sycl::read_only };
-          sycl::accessor accR { bufR, cgh, sycl::write_only };
+          sycl::accessor accA{bufA, cgh, sycl::read_only};
+          sycl::accessor accB{bufB, cgh, sycl::read_only};
+          sycl::accessor accR{bufR, cgh, sycl::write_only};
 
           cgh.parallel_for<vector_add>(
-              sycl::range { dataSize },
+              sycl::range{dataSize},
               [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
         })
         .wait();

--- a/Code_Exercises/Data_and_Dependencies/solution.cpp
+++ b/Code_Exercises/Data_and_Dependencies/solution.cpp
@@ -8,9 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
-
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 class kernel_a_1;
 class kernel_b_1;
@@ -23,8 +23,7 @@ class kernel_d_2;
 
 int usm_selector(const sycl::device& dev) {
   if (dev.has(sycl::aspect::usm_device_allocations)) {
-    if (dev.has(sycl::aspect::gpu))
-      return 2;
+    if (dev.has(sycl::aspect::gpu)) return 2;
     return 1;
   }
   return -1;
@@ -42,47 +41,47 @@ void test_buffer() {
   }
 
   try {
-    auto defaultQueue = sycl::queue {};
+    auto defaultQueue = sycl::queue{};
 
-    auto bufInA = sycl::buffer { inA, sycl::range { dataSize } };
-    auto bufInB = sycl::buffer { inB, sycl::range { dataSize } };
-    auto bufInC = sycl::buffer { inC, sycl::range { dataSize } };
-    auto bufOut = sycl::buffer { out, sycl::range { dataSize } };
+    auto bufInA = sycl::buffer{inA, sycl::range{dataSize}};
+    auto bufInB = sycl::buffer{inB, sycl::range{dataSize}};
+    auto bufInC = sycl::buffer{inC, sycl::range{dataSize}};
+    auto bufOut = sycl::buffer{out, sycl::range{dataSize}};
 
     defaultQueue.submit([&](sycl::handler& cgh) {
-      sycl::accessor acc { bufInA, cgh, sycl::read_write };
+      sycl::accessor acc{bufInA, cgh, sycl::read_write};
 
-      cgh.parallel_for<kernel_a_1>(
-          sycl::range { dataSize },
-          [=](sycl::id<1> idx) { acc[idx] = acc[idx] * 2.0f; });
+      cgh.parallel_for<kernel_a_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
+        acc[idx] = acc[idx] * 2.0f;
+      });
     });
 
     defaultQueue.submit([&](sycl::handler& cgh) {
-      sycl::accessor accIn { bufInA, cgh, sycl::read_only };
-      sycl::accessor accOut { bufInB, cgh, sycl::read_write };
+      sycl::accessor accIn{bufInA, cgh, sycl::read_only};
+      sycl::accessor accOut{bufInB, cgh, sycl::read_write};
 
-      cgh.parallel_for<kernel_b_1>(
-          sycl::range { dataSize },
-          [=](sycl::id<1> idx) { accOut[idx] += accIn[idx]; });
+      cgh.parallel_for<kernel_b_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
+        accOut[idx] += accIn[idx];
+      });
     });
 
     defaultQueue.submit([&](sycl::handler& cgh) {
-      sycl::accessor accIn { bufInA, cgh, sycl::read_only };
-      sycl::accessor accOut { bufInC, cgh, sycl::read_write };
+      sycl::accessor accIn{bufInA, cgh, sycl::read_only};
+      sycl::accessor accOut{bufInC, cgh, sycl::read_write};
 
-      cgh.parallel_for<kernel_c_1>(
-          sycl::range { dataSize },
-          [=](sycl::id<1> idx) { accOut[idx] -= accIn[idx]; });
+      cgh.parallel_for<kernel_c_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
+        accOut[idx] -= accIn[idx];
+      });
     });
 
     defaultQueue.submit([&](sycl::handler& cgh) {
-      sycl::accessor accInA { bufInB, cgh, sycl::read_only };
-      sycl::accessor accInB { bufInC, cgh, sycl::read_only };
-      sycl::accessor accOut { bufOut, cgh, sycl::write_only };
+      sycl::accessor accInA{bufInB, cgh, sycl::read_only};
+      sycl::accessor accInB{bufInC, cgh, sycl::read_only};
+      sycl::accessor accOut{bufOut, cgh, sycl::write_only};
 
-      cgh.parallel_for<kernel_d_1>(
-          sycl::range { dataSize },
-          [=](sycl::id<1> idx) { accOut[idx] = accInA[idx] + accInB[idx]; });
+      cgh.parallel_for<kernel_d_1>(sycl::range{dataSize}, [=](sycl::id<1> idx) {
+        accOut[idx] = accInA[idx] + accInB[idx];
+      });
     });
 
     defaultQueue.wait_and_throw();
@@ -107,7 +106,7 @@ void test_usm() {
   }
 
   try {
-    auto usmQueue = sycl::queue { usm_selector };
+    auto usmQueue = sycl::queue{usm_selector};
 
     auto devicePtrInA = sycl::malloc_device<float>(dataSize, usmQueue);
     auto devicePtrInB = sycl::malloc_device<float>(dataSize, usmQueue);
@@ -119,25 +118,25 @@ void test_usm() {
     auto e3 = usmQueue.memcpy(devicePtrInC, inC, sizeof(float) * dataSize);
 
     auto e4 = usmQueue.parallel_for<kernel_a_2>(
-        sycl::range { dataSize }, e1, [=](sycl::id<1> idx) {
+        sycl::range{dataSize}, e1, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrInA[globalId] = devicePtrInA[globalId] * 2.0f;
         });
 
     auto e5 = usmQueue.parallel_for<kernel_b_2>(
-        sycl::range { dataSize }, { e2, e4 }, [=](sycl::id<1> idx) {
+        sycl::range{dataSize}, {e2, e4}, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrInB[globalId] += devicePtrInA[globalId];
         });
 
     auto e6 = usmQueue.parallel_for<kernel_c_2>(
-        sycl::range { dataSize }, { e3, e4 }, [=](sycl::id<1> idx) {
+        sycl::range{dataSize}, {e3, e4}, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrInC[globalId] -= devicePtrInA[globalId];
         });
 
     auto e7 = usmQueue.parallel_for<kernel_d_2>(
-        sycl::range { dataSize }, { e5, e6 }, [=](sycl::id<1> idx) {
+        sycl::range{dataSize}, {e5, e6}, [=](sycl::id<1> idx) {
           auto globalId = idx[0];
           devicePtrOut[globalId] =
               devicePtrInB[globalId] + devicePtrInC[globalId];

--- a/Code_Exercises/Device_Discovery/solution.cpp
+++ b/Code_Exercises/Device_Discovery/solution.cpp
@@ -8,8 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 class scalar_add;
 
@@ -39,24 +40,23 @@ int main() {
   int a = 18, b = 24, r = 0;
 
   try {
-
-    auto defaultQueue1 = sycl::queue { intel_gpu_selector1 };
-    auto defaultQueue2 = sycl::queue { intel_gpu_selector2 };
+    auto defaultQueue1 = sycl::queue{intel_gpu_selector1};
+    auto defaultQueue2 = sycl::queue{intel_gpu_selector2};
 
     std::cout << "Chosen device: "
               << defaultQueue1.get_device().get_info<sycl::info::device::name>()
               << std::endl;
 
     {
-      auto bufA = sycl::buffer { &a, sycl::range { 1 } };
-      auto bufB = sycl::buffer { &b, sycl::range { 1 } };
-      auto bufR = sycl::buffer { &r, sycl::range { 1 } };
+      auto bufA = sycl::buffer{&a, sycl::range{1}};
+      auto bufB = sycl::buffer{&b, sycl::range{1}};
+      auto bufR = sycl::buffer{&r, sycl::range{1}};
 
       defaultQueue1
           .submit([&](sycl::handler& cgh) {
-            auto accA = sycl::accessor { bufA, cgh, sycl::read_only };
-            auto accB = sycl::accessor { bufB, cgh, sycl::read_only };
-            auto accR = sycl::accessor { bufR, cgh, sycl::write_only };
+            auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
+            auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
+            auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
 
             cgh.single_task<scalar_add>([=]() { accR[0] = accA[0] + accB[0]; });
           })

--- a/Code_Exercises/Device_Discovery/source.cpp
+++ b/Code_Exercises/Device_Discovery/source.cpp
@@ -49,8 +49,9 @@
  *
 */
 
-#include "../helpers.hpp"
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 class scalar_add;
 
@@ -59,18 +60,18 @@ int main() {
 
   try {
     // Task: add a device selector to create this queue with an Intel GPU
-    auto defaultQueue = sycl::queue {};
+    auto defaultQueue = sycl::queue{};
 
     {
-      auto bufA = sycl::buffer { &a, sycl::range { 1 } };
-      auto bufB = sycl::buffer { &b, sycl::range { 1 } };
-      auto bufR = sycl::buffer { &r, sycl::range { 1 } };
+      auto bufA = sycl::buffer{&a, sycl::range{1}};
+      auto bufB = sycl::buffer{&b, sycl::range{1}};
+      auto bufR = sycl::buffer{&r, sycl::range{1}};
 
       defaultQueue
           .submit([&](sycl::handler& cgh) {
-            auto accA = sycl::accessor { bufA, cgh, sycl::read_only };
-            auto accB = sycl::accessor { bufB, cgh, sycl::read_only };
-            auto accR = sycl::accessor { bufR, cgh, sycl::write_only };
+            auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
+            auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
+            auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
 
             cgh.single_task<scalar_add>([=]() { accR[0] = accA[0] + accB[0]; });
           })

--- a/Code_Exercises/Enqueueing_a_Kernel/solution.cpp
+++ b/Code_Exercises/Enqueueing_a_Kernel/solution.cpp
@@ -8,17 +8,18 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 class hello_world;
 
 int main() {
-  auto defaultQueue = sycl::queue {};
+  auto defaultQueue = sycl::queue{};
 
   defaultQueue
       .submit([&](sycl::handler& cgh) {
-        auto os = sycl::stream { 128, 128, cgh };
+        auto os = sycl::stream{128, 128, cgh};
 
         cgh.single_task<hello_world>([=]() { os << "Hello World!\n"; });
       })

--- a/Code_Exercises/Enqueueing_a_Kernel/source.cpp
+++ b/Code_Exercises/Enqueueing_a_Kernel/source.cpp
@@ -34,11 +34,11 @@
  *
  */
 
-#include "../helpers.hpp"
 #include <iostream>
 
-int main() {
+#include "../helpers.hpp"
 
+int main() {
   // Print "Hello World!\n"
   std::cout << "Hello World!\n";
 

--- a/Code_Exercises/Handling_Errors/solution.cpp
+++ b/Code_Exercises/Handling_Errors/solution.cpp
@@ -8,9 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
-
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 int main() {
   try {
@@ -20,14 +20,14 @@ int main() {
       }
     };
 
-    auto defaultQueue = sycl::queue { asyncHandler };
+    auto defaultQueue = sycl::queue{asyncHandler};
 
-    auto buf = sycl::buffer<int>(sycl::range { 1 });
+    auto buf = sycl::buffer<int>(sycl::range{1});
 
     defaultQueue.submit([&](sycl::handler& cgh) {
       // This throws an exception: an accessor has a range which is
       // outside the bounds of its buffer.
-      auto acc = buf.get_access(cgh, sycl::range { 2 }, sycl::read_write);
+      auto acc = buf.get_access(cgh, sycl::range{2}, sycl::read_write);
     });
     defaultQueue.wait_and_throw();
   } catch (const sycl::exception& e) {

--- a/Code_Exercises/Handling_Errors/source.cpp
+++ b/Code_Exercises/Handling_Errors/source.cpp
@@ -8,23 +8,22 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
-
 #include <sycl/sycl.hpp>
 
-int main() {
+#include "../helpers.hpp"
 
+int main() {
   // Task: catch synchronous and asynchronous exceptions
 
-  auto defaultQueue = sycl::queue {};
+  auto defaultQueue = sycl::queue{};
 
-  auto buf = sycl::buffer<int>(sycl::range { 1 });
+  auto buf = sycl::buffer<int>(sycl::range{1});
 
   defaultQueue
       .submit([&](sycl::handler& cgh) {
         // This throws an exception: an accessor has a range which is
         // outside the bounds of its buffer.
-        auto acc = buf.get_access(cgh, sycl::range { 2 }, sycl::read_write);
+        auto acc = buf.get_access(cgh, sycl::range{2}, sycl::read_write);
       })
       .wait();
 

--- a/Code_Exercises/Image_Convolution/reference.cpp
+++ b/Code_Exercises/Image_Convolution/reference.cpp
@@ -8,15 +8,15 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
+#include <benchmark.h>
+#include <image_conv.h>
 
 #include <algorithm>
 #include <iostream>
 
-#include <benchmark.h>
-#include <image_conv.h>
-
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 class image_convolution;
 
@@ -36,7 +36,7 @@ int main() {
   auto filter = util::generate_filter(util::filter_type::blur, filterWidth);
 
   try {
-    sycl::queue myQueue { sycl::gpu_selector_v };
+    sycl::queue myQueue{sycl::gpu_selector_v};
 
     std::cout << "Running on "
               << myQueue.get_device().get_info<sycl::info::device::name>()
@@ -61,29 +61,29 @@ int main() {
     auto filterRange = filterWidth * sycl::range(1, channels);
 
     {
-      auto inBuf = sycl::buffer { inputImage.data(), inBufRange };
-      auto outBuf = sycl::buffer<float, 2> { outBufRange };
-      auto filterBuf = sycl::buffer { filter.data(), filterRange };
+      auto inBuf = sycl::buffer{inputImage.data(), inBufRange};
+      auto outBuf = sycl::buffer<float, 2>{outBufRange};
+      auto filterBuf = sycl::buffer{filter.data(), filterRange};
       outBuf.set_final_data(outputImage.data());
 
       util::benchmark(
           [&]() {
             myQueue.submit([&](sycl::handler& cgh) {
-              sycl::accessor inputAcc { inBuf, cgh, sycl::read_only };
-              sycl::accessor outputAcc { outBuf, cgh, sycl::write_only };
-              sycl::accessor filterAcc { filterBuf, cgh, sycl::read_only };
+              sycl::accessor inputAcc{inBuf, cgh, sycl::read_only};
+              sycl::accessor outputAcc{outBuf, cgh, sycl::write_only};
+              sycl::accessor filterAcc{filterBuf, cgh, sycl::read_only};
 
               cgh.parallel_for<image_convolution>(
                   ndRange, [=](sycl::nd_item<2> item) {
                     auto globalId = item.get_global_id();
-                    globalId = sycl::id { globalId[1], globalId[0] };
+                    globalId = sycl::id{globalId[1], globalId[0]};
 
                     auto channelsStride = sycl::range(1, channels);
                     auto haloOffset = sycl::id(halo, halo);
                     auto src = (globalId + haloOffset) * channelsStride;
                     auto dest = globalId * channelsStride;
 
-                    float sum[4] = { 0.0f, 0.0f, 0.0f, 0.0f };
+                    float sum[4] = {0.0f, 0.0f, 0.0f, 0.0f};
 
                     for (int r = 0; r < filterWidth; ++r) {
                       for (int c = 0; c < filterWidth; ++c) {
@@ -101,7 +101,7 @@ int main() {
                     }
 
                     for (size_t i = 0; i < 4; ++i) {
-                      outputAcc[dest + sycl::id { 0, i }] = sum[i];
+                      outputAcc[dest + sycl::id{0, i}] = sum[i];
                     }
                   });
             });

--- a/Code_Exercises/In_Order_Queue/queue_benchmarking_helpers.hpp
+++ b/Code_Exercises/In_Order_Queue/queue_benchmarking_helpers.hpp
@@ -10,24 +10,25 @@
 
 #include <sycl/sycl.hpp>
 
-#define MAD_4(x, y)                                                            \
-  x = y * x + y;                                                               \
-  y = x * y + x;                                                               \
-  x = y * x + y;                                                               \
+#define MAD_4(x, y) \
+  x = y * x + y;    \
+  y = x * y + x;    \
+  x = y * x + y;    \
   y = x * y + x;
-#define MAD_16(x, y)                                                           \
-  MAD_4(x, y);                                                                 \
-  MAD_4(x, y);                                                                 \
-  MAD_4(x, y);                                                                 \
+#define MAD_16(x, y) \
+  MAD_4(x, y);       \
+  MAD_4(x, y);       \
+  MAD_4(x, y);       \
   MAD_4(x, y);
-#define MAD_64(x, y)                                                           \
-  MAD_16(x, y);                                                                \
-  MAD_16(x, y);                                                                \
-  MAD_16(x, y);                                                                \
+#define MAD_64(x, y) \
+  MAD_16(x, y);      \
+  MAD_16(x, y);      \
+  MAD_16(x, y);      \
   MAD_16(x, y);
 
 // Do some work on device
-template <class T> static T busy_sleep(size_t N, T i) {
+template <class T>
+static T busy_sleep(size_t N, T i) {
   T x = 1.3f;
   T y = i;
   for (size_t j = 0; j < N; j++) {

--- a/Code_Exercises/In_Order_Queue/solution_queue_benchmarking.cpp
+++ b/Code_Exercises/In_Order_Queue/solution_queue_benchmarking.cpp
@@ -22,10 +22,9 @@
 // work done by `numIters` `single_task`s here would be better encapsulated in
 // a single `parallel_for` launch with range `numIters`.
 
-#include "../helpers.hpp"
-
 #include <sycl/sycl.hpp>
 
+#include "../helpers.hpp"
 #include "queue_benchmarking_helpers.hpp"
 
 using T = float;
@@ -33,7 +32,8 @@ using T = float;
 constexpr int numIters = 100;
 
 // Run busy_sleep numKernels times on a single thread using single_task
-template <typename T> auto bench(sycl::queue q, int numKernels) {
+template <typename T>
+auto bench(sycl::queue q, int numKernels) {
   auto* out = sycl::malloc_device<T>(numKernels, q);
 
   auto s = std::chrono::high_resolution_clock::now();
@@ -50,7 +50,6 @@ template <typename T> auto bench(sycl::queue q, int numKernels) {
 template <typename T>
 auto bench_multiple_queues(std::vector<sycl::queue> qs,
                            int numKernelsPerQueue) {
-
   auto* out = sycl::malloc_device<T>(numKernelsPerQueue * qs.size(), qs[0]);
 
   auto s = std::chrono::high_resolution_clock::now();
@@ -67,7 +66,7 @@ auto bench_multiple_queues(std::vector<sycl::queue> qs,
 }
 
 void run_single_queue(sycl::queue q) {
-  bench<T>(q, 1); // Warmup
+  bench<T>(q, 1);  // Warmup
 
   auto singleKernelTime = bench<T>(q, 1);
   auto nKernelsTime = bench<T>(q, numIters);
@@ -80,7 +79,7 @@ void run_single_queue(sycl::queue q) {
 }
 
 void test_in_order_slow() {
-  sycl::queue q { sycl::property::queue::in_order {} };
+  sycl::queue q{sycl::property::queue::in_order{}};
   run_single_queue(q);
 }
 
@@ -90,18 +89,17 @@ void test_out_of_order() {
 }
 
 void test_multiple_in_order_queues() {
-
   constexpr int numKernelsPerQueue = 10;
   constexpr int numQueues = numIters / numKernelsPerQueue;
 
   std::vector<sycl::queue> qs;
   for (int i = 0; i < numQueues; i++) {
-    sycl::queue q { sycl::property::queue::in_order {} };
+    sycl::queue q{sycl::property::queue::in_order{}};
     qs.push_back(q);
   }
-  bench_multiple_queues<T>({ qs[0] }, 1); // Warmup
+  bench_multiple_queues<T>({qs[0]}, 1);  // Warmup
 
-  auto singleKernelTime = bench<T>({ qs[0] }, 1);
+  auto singleKernelTime = bench<T>({qs[0]}, 1);
   auto nKernelsTime = bench_multiple_queues<T>(qs, numQueues);
   std::cout << "1 kernel took: " << singleKernelTime << "ms" << std::endl;
   std::cout << numIters << " in-order kernels took: " << nKernelsTime << "ms"

--- a/Code_Exercises/In_Order_Queue/source_queue_benchmarking.cpp
+++ b/Code_Exercises/In_Order_Queue/source_queue_benchmarking.cpp
@@ -22,10 +22,9 @@
 // work done by `numIters` `single_task`s here would be better encapsulated in
 // a single `parallel_for` launch with range `numIters`.
 
-#include "../helpers.hpp"
-
 #include <sycl/sycl.hpp>
 
+#include "../helpers.hpp"
 #include "queue_benchmarking_helpers.hpp"
 
 using T = float;
@@ -33,7 +32,8 @@ using T = float;
 constexpr int numIters = 100;
 
 // Run busy_sleep numKernels times on a single thread using single_task
-template <typename T> auto bench(sycl::queue q, int numKernels) {
+template <typename T>
+auto bench(sycl::queue q, int numKernels) {
   auto* out = sycl::malloc_device<T>(numKernels, q);
 
   auto s = std::chrono::high_resolution_clock::now();
@@ -46,8 +46,8 @@ template <typename T> auto bench(sycl::queue q, int numKernels) {
 }
 
 void test_in_order_slow() {
-  sycl::queue q { sycl::property::queue::in_order {} };
-  bench<T>(q, 1); // Warmup
+  sycl::queue q{sycl::property::queue::in_order{}};
+  bench<T>(q, 1);  // Warmup
 
   auto singleKernelTime = bench<T>(q, 1);
   auto nKernelsTime = bench<T>(q, numIters);

--- a/Code_Exercises/Introduction_to_USM/solution.cpp
+++ b/Code_Exercises/Introduction_to_USM/solution.cpp
@@ -8,9 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
-
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 int usm_selector(const sycl::device& dev) {
   if (dev.has(sycl::aspect::usm_device_allocations)) {
@@ -21,7 +21,7 @@ int usm_selector(const sycl::device& dev) {
 
 int main() {
   try {
-    auto usmQueue = sycl::queue { usm_selector };
+    auto usmQueue = sycl::queue{usm_selector};
 
     usmQueue.throw_asynchronous();
   } catch (const sycl::exception& e) {

--- a/Code_Exercises/Introduction_to_USM/source.cpp
+++ b/Code_Exercises/Introduction_to_USM/source.cpp
@@ -8,15 +8,14 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
-
 #include <sycl/sycl.hpp>
 
-int main() {
+#include "../helpers.hpp"
 
+int main() {
   // Task: create a queue to a device which supports USM allocations
   // Remember to check for exceptions
-  auto usmQueue = sycl::queue {};
+  auto usmQueue = sycl::queue{};
 
   SYCLACADEMY_ASSERT(true);
 }

--- a/Code_Exercises/Local_Memory_Tiling/solution.cpp
+++ b/Code_Exercises/Local_Memory_Tiling/solution.cpp
@@ -8,15 +8,15 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
+#include <benchmark.h>
+#include <image_conv.h>
 
 #include <algorithm>
 #include <iostream>
 
 #include <sycl/sycl.hpp>
 
-#include <benchmark.h>
-#include <image_conv.h>
+#include "../helpers.hpp"
 
 class image_convolution;
 
@@ -36,7 +36,7 @@ int main() {
   auto filter = util::generate_filter(util::filter_type::blur, filterWidth);
 
   try {
-    sycl::queue myQueue { sycl::gpu_selector_v };
+    sycl::queue myQueue{sycl::gpu_selector_v};
 
     std::cout << "Running on "
               << myQueue.get_device().get_info<sycl::info::device::name>()
@@ -61,9 +61,9 @@ int main() {
     auto scratchpadRange = localRange + sycl::range(halo * 2, halo * 2);
 
     {
-      auto inBuf = sycl::buffer { inputImage.data(), inBufRange };
-      auto outBuf = sycl::buffer<float, 2> { outBufRange };
-      auto filterBuf = sycl::buffer { filter.data(), filterRange };
+      auto inBuf = sycl::buffer{inputImage.data(), inBufRange};
+      auto outBuf = sycl::buffer<float, 2>{outBufRange};
+      auto filterBuf = sycl::buffer{filter.data(), filterRange};
       outBuf.set_final_data(outputImage.data());
 
       auto inBufVec = inBuf.reinterpret<sycl::float4>(inBufRange /
@@ -76,9 +76,9 @@ int main() {
       util::benchmark(
           [&] {
             myQueue.submit([&](sycl::handler& cgh) {
-              sycl::accessor inputAcc { inBufVec, cgh, sycl::read_only };
-              sycl::accessor outputAcc { outBufVec, cgh, sycl::write_only };
-              sycl::accessor filterAcc { filterBufVec, cgh, sycl::read_only };
+              sycl::accessor inputAcc{inBufVec, cgh, sycl::read_only};
+              sycl::accessor outputAcc{outBufVec, cgh, sycl::write_only};
+              sycl::accessor filterAcc{filterBufVec, cgh, sycl::read_only};
 
               auto scratchpad =
                   sycl::local_accessor<sycl::float4, 2>(scratchpadRange, cgh);
@@ -128,7 +128,7 @@ int main() {
 
                     sycl::group_barrier(item.get_group());
 
-                    auto sum = sycl::float4 { 0.0f, 0.0f, 0.0f, 0.0f };
+                    auto sum = sycl::float4{0.0f, 0.0f, 0.0f, 0.0f};
 
                     for (int r = 0; r < filterWidth; ++r) {
                       for (int c = 0; c < filterWidth; ++c) {

--- a/Code_Exercises/Managing_Data/solution.cpp
+++ b/Code_Exercises/Managing_Data/solution.cpp
@@ -8,9 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
-
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 class scalar_add_usm;
 class scalar_add_buff_acc;
@@ -18,7 +18,7 @@ class scalar_add_buff_acc;
 void test_usm() {
   int a = 18, b = 24, r = 0;
 
-  auto defaultQueue = sycl::queue {};
+  auto defaultQueue = sycl::queue{};
 
   auto dev_A = sycl::malloc_device<int>(1, defaultQueue);
   auto dev_B = sycl::malloc_device<int>(1, defaultQueue);
@@ -46,18 +46,18 @@ void test_usm() {
 void test_buffer() {
   int a = 18, b = 24, r = 0;
 
-  auto defaultQueue = sycl::queue {};
+  auto defaultQueue = sycl::queue{};
 
   {
-    auto bufA = sycl::buffer { &a, sycl::range { 1 } };
-    auto bufB = sycl::buffer { &b, sycl::range { 1 } };
-    auto bufR = sycl::buffer { &r, sycl::range { 1 } };
+    auto bufA = sycl::buffer{&a, sycl::range{1}};
+    auto bufB = sycl::buffer{&b, sycl::range{1}};
+    auto bufR = sycl::buffer{&r, sycl::range{1}};
 
     defaultQueue
         .submit([&](sycl::handler& cgh) {
-          auto accA = sycl::accessor { bufA, cgh, sycl::read_only };
-          auto accB = sycl::accessor { bufB, cgh, sycl::read_only };
-          auto accR = sycl::accessor { bufR, cgh, sycl::write_only };
+          auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
+          auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
+          auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
 
           cgh.single_task<scalar_add_buff_acc>(
               [=] { accR[0] = accA[0] + accB[0]; });

--- a/Code_Exercises/Managing_Data/source.cpp
+++ b/Code_Exercises/Managing_Data/source.cpp
@@ -48,7 +48,6 @@
 #include "../helpers.hpp"
 
 void test_usm() {
-
   int a = 18, b = 24, r = 0;
 
   // Task: Compute a+b on the SYCL device using USM
@@ -58,7 +57,6 @@ void test_usm() {
 }
 
 void test_buffer() {
-
   int a = 18, b = 24, r = 0;
 
   // Task: Compute a+b on the SYCL device using the buffer

--- a/Code_Exercises/Matrix_Transpose/solution.cpp
+++ b/Code_Exercises/Matrix_Transpose/solution.cpp
@@ -43,14 +43,14 @@ InTile:               OutTile:
 
 */
 
-#include "../helpers.hpp"
+#include <benchmark.h>
 
 #include <iostream>
 #include <vector>
 
 #include <sycl/sycl.hpp>
 
-#include <benchmark.h>
+#include "../helpers.hpp"
 
 class naive;
 class tiled;
@@ -61,7 +61,6 @@ constexpr size_t numIters = 100;
 using T = float;
 
 int main() {
-
   std::vector<T> A(N * N);
   std::vector<T> A_T(N * N);
   std::vector<T> A_T_comparison(N * N);
@@ -71,30 +70,30 @@ int main() {
   }
 
   try {
-    auto q = sycl::queue {};
+    auto q = sycl::queue{};
 
     std::cout << "Running on "
               << q.get_device().get_info<sycl::info::device::name>() << "\n";
 
-    sycl::range globalRange { N, N };
-    sycl::range localRange { 16, 16 };
-    sycl::nd_range ndRange { globalRange, localRange };
+    sycl::range globalRange{N, N};
+    sycl::range localRange{16, 16};
+    sycl::nd_range ndRange{globalRange, localRange};
 
     {
-      sycl::buffer inBuf { A.data(), globalRange };
-      sycl::buffer outBuf { A_T.data(), globalRange };
-      sycl::buffer compBuf { A_T_comparison.data(), globalRange };
+      sycl::buffer inBuf{A.data(), globalRange};
+      sycl::buffer outBuf{A_T.data(), globalRange};
+      sycl::buffer compBuf{A_T_comparison.data(), globalRange};
 
       util::benchmark(
           [&]() {
             q.submit([&](sycl::handler& cgh) {
-              sycl::accessor inAcc { inBuf, cgh, sycl::read_only };
-              sycl::accessor compAcc { compBuf, cgh, sycl::write_only,
-                                       sycl::property::no_init {} };
+              sycl::accessor inAcc{inBuf, cgh, sycl::read_only};
+              sycl::accessor compAcc{compBuf, cgh, sycl::write_only,
+                                     sycl::property::no_init{}};
 
               cgh.parallel_for<naive>(ndRange, [=](sycl::nd_item<2> item) {
                 auto globalId = item.get_global_id();
-                sycl::id globalIdTranspose { globalId[1], globalId[0] };
+                sycl::id globalIdTranspose{globalId[1], globalId[0]};
                 compAcc[globalIdTranspose] = inAcc[globalId];
               });
             });
@@ -105,19 +104,19 @@ int main() {
       util::benchmark(
           [&]() {
             q.submit([&](sycl::handler& cgh) {
-              sycl::accessor inAcc { inBuf, cgh, sycl::read_only };
-              sycl::accessor outAcc { outBuf, cgh, sycl::write_only,
-                                      sycl::property::no_init {} };
-              sycl::local_accessor<T, 2> localAcc { localRange, cgh };
+              sycl::accessor inAcc{inBuf, cgh, sycl::read_only};
+              sycl::accessor outAcc{outBuf, cgh, sycl::write_only,
+                                    sycl::property::no_init{}};
+              sycl::local_accessor<T, 2> localAcc{localRange, cgh};
 
               cgh.parallel_for<tiled>(ndRange, [=](sycl::nd_item<2> item) {
                 // This kernel assumes that localRange[0] == localRange[1]
                 auto globalId = item.get_global_id();
                 auto localId = item.get_local_id();
-                auto localId_T = sycl::range { localId[1], localId[0] };
+                auto localId_T = sycl::range{localId[1], localId[0]};
                 auto groupOffset = globalId - localId;
                 auto groupOffset_T =
-                    sycl::range { groupOffset[1], groupOffset[0] };
+                    sycl::range{groupOffset[1], groupOffset[0]};
 
                 // Read from global memory in row major and write to local
                 // memory in column major

--- a/Code_Exercises/Matrix_Transpose/source.cpp
+++ b/Code_Exercises/Matrix_Transpose/source.cpp
@@ -14,14 +14,14 @@
  sycl::local_accessor<T, dims> local_acc{localRange, cgh};
 */
 
-#include "../helpers.hpp"
+#include <benchmark.h>
 
 #include <iostream>
 #include <vector>
 
 #include <sycl/sycl.hpp>
 
-#include <benchmark.h>
+#include "../helpers.hpp"
 
 constexpr size_t N = 1024;
 constexpr size_t numIters = 100;
@@ -29,7 +29,6 @@ constexpr size_t numIters = 100;
 using T = float;
 
 int main() {
-
   std::vector<T> A(N * N);
   std::vector<T> A_T(N * N);
   std::vector<T> A_T_comparison(N * N);
@@ -39,30 +38,30 @@ int main() {
   }
 
   try {
-    auto q = sycl::queue {};
+    auto q = sycl::queue{};
 
     std::cout << "Running on "
               << q.get_device().get_info<sycl::info::device::name>() << "\n";
 
-    sycl::range globalRange { N, N };
-    sycl::range localRange { 16, 16 };
-    sycl::nd_range ndRange { globalRange, localRange };
+    sycl::range globalRange{N, N};
+    sycl::range localRange{16, 16};
+    sycl::nd_range ndRange{globalRange, localRange};
 
     {
-      sycl::buffer inBuf { A.data(), globalRange };
-      sycl::buffer outBuf { A_T.data(), globalRange };
-      sycl::buffer compBuf { A_T_comparison.data(), globalRange };
+      sycl::buffer inBuf{A.data(), globalRange};
+      sycl::buffer outBuf{A_T.data(), globalRange};
+      sycl::buffer compBuf{A_T_comparison.data(), globalRange};
 
       util::benchmark(
           [&]() {
             q.submit([&](sycl::handler& cgh) {
-              sycl::accessor inAcc { inBuf, cgh, sycl::read_only };
-              sycl::accessor compAcc { compBuf, cgh, sycl::write_only,
-                                       sycl::property::no_init {} };
+              sycl::accessor inAcc{inBuf, cgh, sycl::read_only};
+              sycl::accessor compAcc{compBuf, cgh, sycl::write_only,
+                                     sycl::property::no_init{}};
 
               cgh.parallel_for(ndRange, [=](sycl::nd_item<2> item) {
                 auto globalId = item.get_global_id();
-                auto globalIdTranspose = sycl::id { globalId[1], globalId[0] };
+                auto globalIdTranspose = sycl::id{globalId[1], globalId[0]};
                 compAcc[globalIdTranspose] = inAcc[globalId];
               });
             });

--- a/Code_Exercises/More_SYCL_Features/reduce_atomic.cpp
+++ b/Code_Exercises/More_SYCL_Features/reduce_atomic.cpp
@@ -12,12 +12,16 @@
  *
  */
 
-#include "../helpers.hpp"
-
 #include <benchmark.h>
+
 #include <sycl/sycl.hpp>
 
-template <typename T> constexpr T my_min(T a, T b) { return a < b ? a : b; }
+#include "../helpers.hpp"
+
+template <typename T>
+constexpr T my_min(T a, T b) {
+  return a < b ? a : b;
+}
 
 using T = float;
 
@@ -26,18 +30,17 @@ constexpr size_t workGroupSize = 1024;
 constexpr int numIters = 100;
 
 int main(int argc, char* argv[]) {
-
   T a[dataSize];
-  T devAns[2] = { 0, 0 };
+  T devAns[2] = {0, 0};
 
   for (auto i = 0; i < dataSize; ++i) {
     a[i] = static_cast<T>(i);
   }
 
-  auto q = sycl::queue {};
+  auto q = sycl::queue{};
 
   T* devA = sycl::malloc_device<T>(dataSize, q);
-  T* devReduced = sycl::malloc_device<T>(1, q); // Holds intermediate values
+  T* devReduced = sycl::malloc_device<T>(1, q);  // Holds intermediate values
 
   T zeroVal = 0;
   auto e1 = q.memcpy(devA, a, sizeof(T) * dataSize);
@@ -48,7 +51,7 @@ int main(int argc, char* argv[]) {
   util::benchmark(
       [&]() {
         q.submit([&](sycl::handler& cgh) {
-           cgh.depends_on({ e1, e2 });
+           cgh.depends_on({e1, e2});
 
            cgh.parallel_for(myNd, [=](sycl::nd_item<1> item) {
              auto globalIdx = item.get_global_linear_id();
@@ -67,7 +70,7 @@ int main(int argc, char* argv[]) {
   util::benchmark(
       [&]() {
         q.submit([&](sycl::handler& cgh) {
-           cgh.depends_on({ e1, e2 });
+           cgh.depends_on({e1, e2});
            sycl::local_accessor<T, 1> localMem(workGroupSize, cgh);
            sycl::local_accessor<T, 1> localReduction(1, cgh);
 
@@ -76,8 +79,7 @@ int main(int argc, char* argv[]) {
              auto globalIdx = item.get_global_linear_id();
              auto globalRange = item.get_global_range(0);
 
-             if (localIdx == 0)
-               localReduction[0] = 0;
+             if (localIdx == 0) localReduction[0] = 0;
 
              item.barrier();
 

--- a/Code_Exercises/More_SYCL_Features/reduce_group_algorithms.cpp
+++ b/Code_Exercises/More_SYCL_Features/reduce_group_algorithms.cpp
@@ -8,10 +8,11 @@
  *
  */
 
-#include "../helpers.hpp"
-
 #include <benchmark.h>
+
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 using T = float;
 
@@ -20,17 +21,16 @@ constexpr size_t workGroupSize = 1024;
 constexpr int numIters = 100;
 
 int main(int argc, char* argv[]) {
-
   T a[dataSize];
 
   for (auto i = 0; i < dataSize; ++i) {
     a[i] = static_cast<T>(i);
   }
 
-  auto q = sycl::queue {};
+  auto q = sycl::queue{};
 
   T* devA = sycl::malloc_device<T>(dataSize, q);
-  T* devReduced = sycl::malloc_device<T>(1, q); // Holds reduction output
+  T* devReduced = sycl::malloc_device<T>(1, q);  // Holds reduction output
 
   auto e1 = q.memcpy(devA, a, sizeof(T) * dataSize);
   auto e2 = q.fill(devReduced, 0, 1);
@@ -40,7 +40,7 @@ int main(int argc, char* argv[]) {
   util::benchmark(
       [&]() {
         q.submit([&](sycl::handler& cgh) {
-           cgh.depends_on({ e1, e2 });
+           cgh.depends_on({e1, e2});
            sycl::local_accessor<T, 1> localMem(workGroupSize, cgh);
 
            cgh.parallel_for(myNd, [=](sycl::nd_item<1> item) {

--- a/Code_Exercises/More_SYCL_Features/reduce_naive.cpp
+++ b/Code_Exercises/More_SYCL_Features/reduce_naive.cpp
@@ -11,12 +11,16 @@
  *
  */
 
-#include "../helpers.hpp"
-
 #include <benchmark.h>
+
 #include <sycl/sycl.hpp>
 
-template <typename T> constexpr T my_min(T a, T b) { return a < b ? a : b; }
+#include "../helpers.hpp"
+
+template <typename T>
+constexpr T my_min(T a, T b) {
+  return a < b ? a : b;
+}
 
 using T = float;
 
@@ -35,26 +39,24 @@ inline void workgroup_reduce_local_mem(sycl::local_accessor<T, 1> a,
 #pragma unroll
   for (auto i = workGroupSize; i >= 2; i /= 2) {
     if (workGroupSize >= i) {
-      if (localIdx < i / 2)
-        a[localIdx] += a[localIdx + i / 2];
+      if (localIdx < i / 2) a[localIdx] += a[localIdx + i / 2];
       item.barrier();
     }
   }
 }
 
 int main(int argc, char* argv[]) {
-
   T a[dataSize];
 
   for (auto i = 0; i < dataSize; ++i) {
     a[i] = static_cast<T>(i);
   }
 
-  auto q = sycl::queue {};
+  auto q = sycl::queue{};
 
   T* devPtrA = sycl::malloc_device<T>(dataSize, q);
   T* devPtrB =
-      sycl::malloc_device<T>(numWorkGroups, q); // Holds intermediate values
+      sycl::malloc_device<T>(numWorkGroups, q);  // Holds intermediate values
 
   auto e1 = q.memcpy(devPtrA, a, sizeof(T) * dataSize);
 

--- a/Code_Exercises/More_SYCL_Features/reduce_sycl_reduction.cpp
+++ b/Code_Exercises/More_SYCL_Features/reduce_sycl_reduction.cpp
@@ -4,10 +4,11 @@
  *
  */
 
-#include "../helpers.hpp"
-
 #include <benchmark.h>
+
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 using T = float;
 
@@ -16,17 +17,16 @@ constexpr size_t workGroupSize = 1024;
 constexpr int numIters = 100;
 
 int main(int argc, char* argv[]) {
-
   T a[dataSize];
 
   for (auto i = 0; i < dataSize; ++i) {
     a[i] = static_cast<T>(i);
   }
 
-  auto q = sycl::queue {};
+  auto q = sycl::queue{};
 
   T* devA = sycl::malloc_device<T>(dataSize, q);
-  T* devReduced = sycl::malloc_device<T>(1, q); // Holds intermediate values
+  T* devReduced = sycl::malloc_device<T>(1, q);  // Holds intermediate values
 
   T zeroVal = 0;
   auto e1 = q.memcpy(devA, a, sizeof(T) * dataSize);
@@ -37,10 +37,10 @@ int main(int argc, char* argv[]) {
   util::benchmark(
       [&]() {
         q.submit([&](sycl::handler& cgh) {
-           cgh.depends_on({ e1, e2 });
+           cgh.depends_on({e1, e2});
            auto myReduction = sycl::reduction(
                devReduced, sycl::plus<T>(),
-               sycl::property::reduction::initialize_to_identity {});
+               sycl::property::reduction::initialize_to_identity{});
 
            cgh.parallel_for(myNd, myReduction,
                             [=](sycl::nd_item<1> item, auto& sum) {

--- a/Code_Exercises/Multiple_Devices/solution.cpp
+++ b/Code_Exercises/Multiple_Devices/solution.cpp
@@ -8,11 +8,11 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
+#include <algorithm>
 
 #include <sycl/sycl.hpp>
 
-#include <algorithm>
+#include "../helpers.hpp"
 
 class vector_add_first;
 class vector_add_second;
@@ -21,11 +21,9 @@ class vector_add_second;
 // allowing computation to be split across said devices.
 std::vector<sycl::device> get_two_devices() {
   auto devs = sycl::device::get_devices();
-  if (devs.size() == 0)
-    throw "No devices available";
-  if (devs.size() == 1)
-    return { devs[0], devs[0] };
-  return { devs[0], devs[1] };
+  if (devs.size() == 0) throw "No devices available";
+  if (devs.size() == 1) return {devs[0], devs[0]};
+  return {devs[0], devs[1]};
 }
 
 int main() {
@@ -43,9 +41,9 @@ int main() {
 
   try {
     auto devs = get_two_devices();
-    auto Q1 = sycl::queue { devs[0] };
-    auto Q2 = sycl::queue { devs[1] }; // if only one device is found, both
-                                       // queues will use same device
+    auto Q1 = sycl::queue{devs[0]};
+    auto Q2 = sycl::queue{devs[1]};  // if only one device is found, both
+                                     // queues will use same device
 
     std::cout << "Running on devices:" << std::endl;
     std::cout << "1:\t" << Q1.get_device().get_info<sycl::info::device::name>()
@@ -53,34 +51,34 @@ int main() {
     std::cout << "2:\t" << Q2.get_device().get_info<sycl::info::device::name>()
               << std::endl;
 
-    auto bufFirstA = sycl::buffer { a, sycl::range { dataSizeFirst } };
-    auto bufFirstB = sycl::buffer { b, sycl::range { dataSizeFirst } };
-    auto bufFirstR = sycl::buffer { r, sycl::range { dataSizeFirst } };
+    auto bufFirstA = sycl::buffer{a, sycl::range{dataSizeFirst}};
+    auto bufFirstB = sycl::buffer{b, sycl::range{dataSizeFirst}};
+    auto bufFirstR = sycl::buffer{r, sycl::range{dataSizeFirst}};
 
     auto bufSecondA =
-        sycl::buffer { a + dataSizeFirst, sycl::range { dataSizeSecond } };
+        sycl::buffer{a + dataSizeFirst, sycl::range{dataSizeSecond}};
     auto bufSecondB =
-        sycl::buffer { b + dataSizeFirst, sycl::range { dataSizeSecond } };
+        sycl::buffer{b + dataSizeFirst, sycl::range{dataSizeSecond}};
     auto bufSecondR =
-        sycl::buffer { r + dataSizeFirst, sycl::range { dataSizeSecond } };
+        sycl::buffer{r + dataSizeFirst, sycl::range{dataSizeSecond}};
 
     Q1.submit([&](sycl::handler& cgh) {
-      sycl::accessor accA { bufFirstA, cgh, sycl::read_only };
-      sycl::accessor accB { bufFirstB, cgh, sycl::read_only };
-      sycl::accessor accR { bufFirstR, cgh, sycl::write_only };
+      sycl::accessor accA{bufFirstA, cgh, sycl::read_only};
+      sycl::accessor accB{bufFirstB, cgh, sycl::read_only};
+      sycl::accessor accR{bufFirstR, cgh, sycl::write_only};
 
       cgh.parallel_for<vector_add_first>(
-          sycl::range { dataSizeFirst },
+          sycl::range{dataSizeFirst},
           [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
     });
 
     Q2.submit([&](sycl::handler& cgh) {
-      sycl::accessor accA { bufSecondA, cgh, sycl::read_only };
-      sycl::accessor accB { bufSecondB, cgh, sycl::read_only };
-      sycl::accessor accR { bufSecondR, cgh, sycl::write_only };
+      sycl::accessor accA{bufSecondA, cgh, sycl::read_only};
+      sycl::accessor accB{bufSecondB, cgh, sycl::read_only};
+      sycl::accessor accR{bufSecondR, cgh, sycl::write_only};
 
       cgh.parallel_for<vector_add_second>(
-          sycl::range { dataSizeSecond },
+          sycl::range{dataSizeSecond},
           [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
     });
 

--- a/Code_Exercises/ND_Range_Kernel/solution.cpp
+++ b/Code_Exercises/ND_Range_Kernel/solution.cpp
@@ -8,9 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
-
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 class vector_add_1;
 class vector_add_2;
@@ -26,19 +26,19 @@ void test_item() {
   }
 
   try {
-    auto gpuQueue = sycl::queue { sycl::gpu_selector_v };
+    auto gpuQueue = sycl::queue{sycl::gpu_selector_v};
 
-    auto bufA = sycl::buffer { a, sycl::range { dataSize } };
-    auto bufB = sycl::buffer { b, sycl::range { dataSize } };
-    auto bufR = sycl::buffer { r, sycl::range { dataSize } };
+    auto bufA = sycl::buffer{a, sycl::range{dataSize}};
+    auto bufB = sycl::buffer{b, sycl::range{dataSize}};
+    auto bufR = sycl::buffer{r, sycl::range{dataSize}};
 
     gpuQueue.submit([&](sycl::handler& cgh) {
-      sycl::accessor accA { bufA, cgh, sycl::read_only };
-      sycl::accessor accB { bufB, cgh, sycl::read_only };
-      sycl::accessor accR { bufR, cgh, sycl::write_only };
+      sycl::accessor accA{bufA, cgh, sycl::read_only};
+      sycl::accessor accB{bufB, cgh, sycl::read_only};
+      sycl::accessor accR{bufR, cgh, sycl::write_only};
 
       cgh.parallel_for<vector_add_1>(
-          sycl::range { dataSize }, [=](sycl::item<1> itm) {
+          sycl::range{dataSize}, [=](sycl::item<1> itm) {
             auto globalId = itm.get_id();
             accR[globalId] = accA[globalId] + accB[globalId];
           });
@@ -66,19 +66,19 @@ void test_nd_item() {
   }
 
   try {
-    auto gpuQueue = sycl::queue { sycl::gpu_selector_v };
+    auto gpuQueue = sycl::queue{sycl::gpu_selector_v};
 
-    auto bufA = sycl::buffer { a, sycl::range { dataSize } };
-    auto bufB = sycl::buffer { b, sycl::range { dataSize } };
-    auto bufR = sycl::buffer { r, sycl::range { dataSize } };
+    auto bufA = sycl::buffer{a, sycl::range{dataSize}};
+    auto bufB = sycl::buffer{b, sycl::range{dataSize}};
+    auto bufR = sycl::buffer{r, sycl::range{dataSize}};
 
     gpuQueue.submit([&](sycl::handler& cgh) {
-      sycl::accessor accA { bufA, cgh, sycl::read_write };
-      sycl::accessor accB { bufB, cgh, sycl::read_write };
-      sycl::accessor accR { bufR, cgh, sycl::read_write };
+      sycl::accessor accA{bufA, cgh, sycl::read_write};
+      sycl::accessor accB{bufB, cgh, sycl::read_write};
+      sycl::accessor accR{bufR, cgh, sycl::read_write};
 
-      auto ndRange = sycl::nd_range { sycl::range { dataSize },
-                                      sycl::range { workGroupSize } };
+      auto ndRange =
+          sycl::nd_range{sycl::range{dataSize}, sycl::range{workGroupSize}};
 
       cgh.parallel_for<vector_add_2>(ndRange, [=](sycl::nd_item<1> itm) {
         auto globalId = itm.get_global_id();

--- a/Code_Exercises/OneMKL_gemm/solution_onemkl_buffer_gemm.cpp
+++ b/Code_Exercises/OneMKL_gemm/solution_onemkl_buffer_gemm.cpp
@@ -20,13 +20,13 @@
 
 #include <iostream>
 #include <limits>
+#include <oneapi/mkl/blas.hpp>
 #include <random>
 
-#include <oneapi/mkl/blas.hpp>
 #include <sycl/sycl.hpp>
 
 // Matrix size constants
-constexpr size_t SIZE = 4800; // Must be a multiple of 8.
+constexpr size_t SIZE = 4800;  // Must be a multiple of 8.
 constexpr size_t M = SIZE / 8;
 constexpr size_t N = SIZE / 4;
 constexpr size_t P = SIZE / 2;
@@ -75,8 +75,8 @@ void print_device_info(sycl::queue& Q) {
 
 int main() {
   std::random_device
-      rd; // Will be used to obtain a seed for the random number engine
-  std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
+      rd;  // Will be used to obtain a seed for the random number engine
+  std::mt19937 gen(rd());  // Standard mersenne_twister_engine seeded with rd()
   std::uniform_real_distribution<> dis(1.0, 2.0);
 
   // matrix data sizes
@@ -103,12 +103,10 @@ int main() {
 
   // A(M, N)
   for (size_t i = 0; i < M; i++)
-    for (size_t j = 0; j < N; j++)
-      A[i * N + j] = dis(gen);
+    for (size_t j = 0; j < N; j++) A[i * N + j] = dis(gen);
   // B(N, P)
   for (size_t i = 0; i < N; i++)
-    for (size_t j = 0; j < P; j++)
-      B[i * P + j] = dis(gen);
+    for (size_t j = 0; j < P; j++) B[i * P + j] = dis(gen);
 
   // Resultant matrix: C_serial = A*B
   for (size_t i = 0; i < M; i++) {
@@ -120,15 +118,15 @@ int main() {
   }
 
   // Create a SYCL in-order queue targetting GPU device
-  sycl::queue Q { sycl::gpu_selector_v, sycl::property::queue::in_order {} };
+  sycl::queue Q{sycl::gpu_selector_v, sycl::property::queue::in_order{}};
   // Prints some basic info related to the hardware
   print_device_info(Q);
 
   // TODO: Allocate memory on device, (using sycl::malloc_device APIs)
   // Creating 1D buffers for matrices which are bound to host memory array
-  sycl::buffer<T, 1> a { A.data(), sycl::range<1> { M * N } };
-  sycl::buffer<T, 1> b { B.data(), sycl::range<1> { N * P } };
-  sycl::buffer<T, 1> c { C_host.data(), sycl::range<1> { M * P } };
+  sycl::buffer<T, 1> a{A.data(), sycl::range<1>{M * N}};
+  sycl::buffer<T, 1> b{B.data(), sycl::range<1>{N * P}};
+  sycl::buffer<T, 1> c{C_host.data(), sycl::range<1>{M * P}};
 
   // TODO: Use oneMKL GEMM USM API
   oneapi::mkl::transpose transA = oneapi::mkl::transpose::nontrans;
@@ -136,7 +134,7 @@ int main() {
   oneapi::mkl::blas::column_major::gemm(Q, transA, transB, n, m, k, alpha, b,
                                         ldB, a, ldA, beta, c, ldC);
   Q.wait();
-  sycl::host_accessor C_device { c };
+  sycl::host_accessor C_device{c};
 
   // Verify results from oneMKL APIs
   int result = 0;

--- a/Code_Exercises/OneMKL_gemm/solution_onemkl_usm_gemm.cpp
+++ b/Code_Exercises/OneMKL_gemm/solution_onemkl_usm_gemm.cpp
@@ -20,13 +20,13 @@
 
 #include <iostream>
 #include <limits>
+#include <oneapi/mkl/blas.hpp>
 #include <random>
 
-#include <oneapi/mkl/blas.hpp>
 #include <sycl/sycl.hpp>
 
 // Matrix size constants
-constexpr size_t SIZE = 4800; // Must be a multiple of 8.
+constexpr size_t SIZE = 4800;  // Must be a multiple of 8.
 constexpr size_t M = SIZE / 8;
 constexpr size_t N = SIZE / 4;
 constexpr size_t P = SIZE / 2;
@@ -75,8 +75,8 @@ void print_device_info(sycl::queue& Q) {
 
 int main() {
   std::random_device
-      rd; // Will be used to obtain a seed for the random number engine
-  std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
+      rd;  // Will be used to obtain a seed for the random number engine
+  std::mt19937 gen(rd());  // Standard mersenne_twister_engine seeded with rd()
   std::uniform_real_distribution<> dis(1.0, 2.0);
 
   // matrix data sizes
@@ -103,12 +103,10 @@ int main() {
 
   // A(M, N)
   for (size_t i = 0; i < M; i++)
-    for (size_t j = 0; j < N; j++)
-      A[i * N + j] = dis(gen);
+    for (size_t j = 0; j < N; j++) A[i * N + j] = dis(gen);
   // B(N, P)
   for (size_t i = 0; i < N; i++)
-    for (size_t j = 0; j < P; j++)
-      B[i * P + j] = dis(gen);
+    for (size_t j = 0; j < P; j++) B[i * P + j] = dis(gen);
 
   // Resultant matrix: C_serial = A*B
   for (size_t i = 0; i < M; i++) {
@@ -120,7 +118,7 @@ int main() {
   }
 
   // Create a SYCL in-order queue targetting GPU device
-  sycl::queue Q { sycl::gpu_selector_v, sycl::property::queue::in_order {} };
+  sycl::queue Q{sycl::gpu_selector_v, sycl::property::queue::in_order{}};
   // Prints some basic info related to the hardware
   print_device_info(Q);
 
@@ -135,7 +133,8 @@ int main() {
   oneapi::mkl::transpose transA = oneapi::mkl::transpose::nontrans;
   oneapi::mkl::transpose transB = oneapi::mkl::transpose::nontrans;
   oneapi::mkl::blas::column_major::gemm(Q, transA, transB, n, m, k, alpha, b,
-                                        ldB, a, ldA, beta, c, ldC); // row-major
+                                        ldB, a, ldA, beta, c,
+                                        ldC);  // row-major
 
   std::vector<T> C_device(M * P);
   Q.memcpy(C_device.data(), c, sizeof(T) * M * P);

--- a/Code_Exercises/OneMKL_gemm/source_onemkl_buffer_gemm.cpp
+++ b/Code_Exercises/OneMKL_gemm/source_onemkl_buffer_gemm.cpp
@@ -20,13 +20,13 @@
 
 #include <iostream>
 #include <limits>
+#include <oneapi/mkl/blas.hpp>
 #include <random>
 
-#include <oneapi/mkl/blas.hpp>
 #include <sycl/sycl.hpp>
 
 // Matrix size constants
-constexpr size_t SIZE = 4800; // Must be a multiple of 8.
+constexpr size_t SIZE = 4800;  // Must be a multiple of 8.
 constexpr size_t M = SIZE / 8;
 constexpr size_t N = SIZE / 4;
 constexpr size_t P = SIZE / 2;
@@ -75,8 +75,8 @@ void print_device_info(sycl::queue& Q) {
 
 int main() {
   std::random_device
-      rd; // Will be used to obtain a seed for the random number engine
-  std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
+      rd;  // Will be used to obtain a seed for the random number engine
+  std::mt19937 gen(rd());  // Standard mersenne_twister_engine seeded with rd()
   std::uniform_real_distribution<> dis(1.0, 2.0);
 
   // matrix data sizes
@@ -103,12 +103,10 @@ int main() {
 
   // A(M, N)
   for (size_t i = 0; i < M; i++)
-    for (size_t j = 0; j < N; j++)
-      A[i * N + j] = dis(gen);
+    for (size_t j = 0; j < N; j++) A[i * N + j] = dis(gen);
   // B(N, P)
   for (size_t i = 0; i < N; i++)
-    for (size_t j = 0; j < P; j++)
-      B[i * P + j] = dis(gen);
+    for (size_t j = 0; j < P; j++) B[i * P + j] = dis(gen);
 
   // Resultant matrix: C_serial = A*B
   for (size_t i = 0; i < M; i++) {
@@ -120,7 +118,7 @@ int main() {
   }
 
   // Create a SYCL in-order queue targetting GPU device
-  sycl::queue Q { sycl::gpu_selector_v, sycl::property::queue::in_order {} };
+  sycl::queue Q{sycl::gpu_selector_v, sycl::property::queue::in_order{}};
   // Prints some basic info related to the hardware
   print_device_info(Q);
 

--- a/Code_Exercises/OneMKL_gemm/source_onemkl_usm_gemm.cpp
+++ b/Code_Exercises/OneMKL_gemm/source_onemkl_usm_gemm.cpp
@@ -20,13 +20,13 @@
 
 #include <iostream>
 #include <limits>
+#include <oneapi/mkl/blas.hpp>
 #include <random>
 
-#include <oneapi/mkl/blas.hpp>
 #include <sycl/sycl.hpp>
 
 // Matrix size constants
-constexpr size_t SIZE = 4800; // Must be a multiple of 8.
+constexpr size_t SIZE = 4800;  // Must be a multiple of 8.
 constexpr size_t M = SIZE / 8;
 constexpr size_t N = SIZE / 4;
 constexpr size_t P = SIZE / 2;
@@ -75,8 +75,8 @@ void print_device_info(sycl::queue& Q) {
 
 int main() {
   std::random_device
-      rd; // Will be used to obtain a seed for the random number engine
-  std::mt19937 gen(rd()); // Standard mersenne_twister_engine seeded with rd()
+      rd;  // Will be used to obtain a seed for the random number engine
+  std::mt19937 gen(rd());  // Standard mersenne_twister_engine seeded with rd()
   std::uniform_real_distribution<> dis(1.0, 2.0);
 
   // matrix data sizes
@@ -103,12 +103,10 @@ int main() {
 
   // A(M, N)
   for (size_t i = 0; i < M; i++)
-    for (size_t j = 0; j < N; j++)
-      A[i * N + j] = dis(gen);
+    for (size_t j = 0; j < N; j++) A[i * N + j] = dis(gen);
   // B(N, P)
   for (size_t i = 0; i < N; i++)
-    for (size_t j = 0; j < P; j++)
-      B[i * P + j] = dis(gen);
+    for (size_t j = 0; j < P; j++) B[i * P + j] = dis(gen);
 
   // Resultant matrix: C_serial = A*B
   for (size_t i = 0; i < M; i++) {
@@ -120,7 +118,7 @@ int main() {
   }
 
   // Create a SYCL in-order queue targetting GPU device
-  sycl::queue Q { sycl::gpu_selector_v, sycl::property::queue::in_order {} };
+  sycl::queue Q{sycl::gpu_selector_v, sycl::property::queue::in_order{}};
   // Prints some basic info related to the hardware
   print_device_info(Q);
 

--- a/Code_Exercises/Using_USM/solution.cpp
+++ b/Code_Exercises/Using_USM/solution.cpp
@@ -8,9 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
-
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 class vector_add;
 
@@ -32,7 +32,7 @@ int main() {
   }
 
   try {
-    auto usmQueue = sycl::queue { usm_selector };
+    auto usmQueue = sycl::queue{usm_selector};
 
     auto devicePtrA = sycl::malloc_device<float>(dataSize, usmQueue);
     auto devicePtrB = sycl::malloc_device<float>(dataSize, usmQueue);
@@ -42,7 +42,7 @@ int main() {
     usmQueue.memcpy(devicePtrB, b, sizeof(float) * dataSize).wait();
 
     usmQueue
-        .parallel_for<vector_add>(sycl::range { dataSize },
+        .parallel_for<vector_add>(sycl::range{dataSize},
                                   [=](sycl::id<1> idx) {
                                     auto globalId = idx[0];
                                     devicePtrR[globalId] =

--- a/Code_Exercises/Vectors/solution.cpp
+++ b/Code_Exercises/Vectors/solution.cpp
@@ -8,15 +8,15 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
+#include <benchmark.h>
+#include <image_conv.h>
 
 #include <algorithm>
 #include <iostream>
 
 #include <sycl/sycl.hpp>
 
-#include <benchmark.h>
-#include <image_conv.h>
+#include "../helpers.hpp"
 
 class image_convolution;
 
@@ -36,7 +36,7 @@ int main() {
   auto filter = util::generate_filter(util::filter_type::blur, filterWidth);
 
   try {
-    sycl::queue myQueue { sycl::gpu_selector_v };
+    sycl::queue myQueue{sycl::gpu_selector_v};
 
     std::cout << "Running on "
               << myQueue.get_device().get_info<sycl::info::device::name>()
@@ -60,9 +60,9 @@ int main() {
     auto filterRange = filterWidth * sycl::range(1, channels);
 
     {
-      auto inBuf = sycl::buffer { inputImage.data(), inBufRange };
-      auto outBuf = sycl::buffer<float, 2> { outBufRange };
-      auto filterBuf = sycl::buffer { filter.data(), filterRange };
+      auto inBuf = sycl::buffer{inputImage.data(), inBufRange};
+      auto outBuf = sycl::buffer<float, 2>{outBufRange};
+      auto filterBuf = sycl::buffer{filter.data(), filterRange};
       outBuf.set_final_data(outputImage.data());
 
       auto inBufVec = inBuf.reinterpret<sycl::float4>(inBufRange /
@@ -75,9 +75,9 @@ int main() {
       util::benchmark(
           [&]() {
             myQueue.submit([&](sycl::handler& cgh) {
-              sycl::accessor inputAcc { inBufVec, cgh, sycl::read_only };
-              sycl::accessor outputAcc { outBufVec, cgh, sycl::write_only };
-              sycl::accessor filterAcc { filterBufVec, cgh, sycl::read_only };
+              sycl::accessor inputAcc{inBufVec, cgh, sycl::read_only};
+              sycl::accessor outputAcc{outBufVec, cgh, sycl::write_only};
+              sycl::accessor filterAcc{filterBufVec, cgh, sycl::read_only};
 
               cgh.parallel_for<image_convolution>(
                   ndRange, [=](sycl::nd_item<2> item) {
@@ -87,7 +87,7 @@ int main() {
                     auto src = (globalId + haloOffset);
                     auto dest = globalId;
 
-                    auto sum = sycl::float4 { 0.0f, 0.0f, 0.0f, 0.0f };
+                    auto sum = sycl::float4{0.0f, 0.0f, 0.0f, 0.0f};
 
                     for (int r = 0; r < filterWidth; ++r) {
                       for (int c = 0; c < filterWidth; ++c) {

--- a/Code_Exercises/What_is_SYCL/solution.cpp
+++ b/Code_Exercises/What_is_SYCL/solution.cpp
@@ -8,8 +8,9 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
 #include <sycl/sycl.hpp>
+
+#include "../helpers.hpp"
 
 // The below tests that the header file has been included
 int main() { SYCLACADEMY_ASSERT(true); }

--- a/Code_Exercises/Work_Group_Sizes/solution.cpp
+++ b/Code_Exercises/Work_Group_Sizes/solution.cpp
@@ -8,15 +8,15 @@
  work.  If not, see <http://creativecommons.org/licenses/by-sa/4.0/>.
 */
 
-#include "../helpers.hpp"
+#include <benchmark.h>
+#include <image_conv.h>
 
 #include <algorithm>
 #include <iostream>
 
 #include <sycl/sycl.hpp>
 
-#include <benchmark.h>
-#include <image_conv.h>
+#include "../helpers.hpp"
 
 class image_convolution;
 
@@ -36,7 +36,7 @@ int main() {
   auto filter = util::generate_filter(util::filter_type::blur, filterWidth);
 
   try {
-    sycl::queue myQueue { sycl::gpu_selector_v };
+    sycl::queue myQueue{sycl::gpu_selector_v};
 
     std::cout << "Running on "
               << myQueue.get_device().get_info<sycl::info::device::name>()
@@ -61,9 +61,9 @@ int main() {
     auto scratchpadRange = localRange + sycl::range(halo * 2, halo * 2);
 
     {
-      auto inBuf = sycl::buffer { inputImage.data(), inBufRange };
-      auto outBuf = sycl::buffer<float, 2> { outBufRange };
-      auto filterBuf = sycl::buffer { filter.data(), filterRange };
+      auto inBuf = sycl::buffer{inputImage.data(), inBufRange};
+      auto outBuf = sycl::buffer<float, 2>{outBufRange};
+      auto filterBuf = sycl::buffer{filter.data(), filterRange};
       outBuf.set_final_data(outputImage.data());
 
       auto inBufVec = inBuf.reinterpret<sycl::float4>(inBufRange /
@@ -76,9 +76,9 @@ int main() {
       util::benchmark(
           [&] {
             myQueue.submit([&](sycl::handler& cgh) {
-              sycl::accessor inputAcc { inBufVec, cgh, sycl::read_only };
-              sycl::accessor outputAcc { outBufVec, cgh, sycl::write_only };
-              sycl::accessor filterAcc { filterBufVec, cgh, sycl::read_only };
+              sycl::accessor inputAcc{inBufVec, cgh, sycl::read_only};
+              sycl::accessor outputAcc{outBufVec, cgh, sycl::write_only};
+              sycl::accessor filterAcc{filterBufVec, cgh, sycl::read_only};
 
               auto scratchpad =
                   sycl::local_accessor<sycl::float4, 2>(scratchpadRange, cgh);
@@ -101,7 +101,7 @@ int main() {
 
                     sycl::group_barrier(item.get_group());
 
-                    auto sum = sycl::float4 { 0.0f, 0.0f, 0.0f, 0.0f };
+                    auto sum = sycl::float4{0.0f, 0.0f, 0.0f, 0.0f};
 
                     for (int r = 0; r < filterWidth; ++r) {
                       for (int c = 0; c < filterWidth; ++c) {

--- a/Code_Exercises/helpers.hpp
+++ b/Code_Exercises/helpers.hpp
@@ -10,16 +10,16 @@
 
 #pragma once
 
-#include <cstddef> // for size_t
+#include <cstddef>  // for size_t
 
 #ifndef __SYCL_DEVICE_ONLY__
-#include <cstdio>  // fprintf
-#include <cstdlib> // abort
-#define SYCLACADEMY_ASSERT(cond)                                               \
-  if (!(cond)) {                                                               \
-    std::fprintf(stderr, "%s failed in %s:%d:%s\nExiting\n", #cond,            \
-                 __BASE_FILE__, __LINE__, __FUNCTION__);                       \
-    std::abort();                                                              \
+#include <cstdio>   // fprintf
+#include <cstdlib>  // abort
+#define SYCLACADEMY_ASSERT(cond)                                    \
+  if (!(cond)) {                                                    \
+    std::fprintf(stderr, "%s failed in %s:%d:%s\nExiting\n", #cond, \
+                 __BASE_FILE__, __LINE__, __FUNCTION__);            \
+    std::abort();                                                   \
   }
 #else
 #define SYCLACADEMY_ASSERT(cond) void(0);


### PR DESCRIPTION
Change the `.clang-format` style config to the same as we use in [SYCL-samples](https://github.com/codeplaysoftware/SYCL-samples) which is just the plain Google style + an updated sorting rules for includes to place `<sycl/sycl.hpp>` in between system and local headers.

Apply the style and add a CI workflow checking if the code is correctly formatted.

This is based on feedback from a recent workshop where participants disliked the formatting / found it confusing.