### PR TITLE
Extend helper assert with generic comparison and print message on success

### DIFF
--- a/Code_Exercises/Advanced_Data_Flow/solution.cpp
+++ b/Code_Exercises/Advanced_Data_Flow/solution.cpp
@@ -67,9 +67,7 @@ void test_buffer() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(out[i] == i * 4.0f);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(out, [](size_t i) { return i * 4.0f; });
 }
 
 void test_usm() {
@@ -118,9 +116,7 @@ void test_usm() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(out[i] == i * 4.0f);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(out, [](size_t i) { return i * 4.0f; });
 }
 
 int main() {

--- a/Code_Exercises/Advanced_Data_Flow/source.cpp
+++ b/Code_Exercises/Advanced_Data_Flow/source.cpp
@@ -73,7 +73,5 @@ int main() {
     out[i] = tmp[i] / 2.0f;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(out[i] == i * 4.0f);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(out, [](size_t i) { return i * 4.0f; });
 }

--- a/Code_Exercises/Asynchronous_Execution/solution.cpp
+++ b/Code_Exercises/Asynchronous_Execution/solution.cpp
@@ -61,9 +61,7 @@ void test_buffer_event_wait() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(r[i] == i * 2);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2; });
 }
 
 void test_buffer_queue_wait() {
@@ -98,9 +96,7 @@ void test_buffer_queue_wait() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(r[i] == i * 2);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2; });
 }
 
 void test_buffer_buffer_destruction() {
@@ -137,9 +133,7 @@ void test_buffer_buffer_destruction() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(r[i] == i * 2);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2; });
 }
 
 void test_usm_event_wait() {
@@ -189,9 +183,7 @@ void test_usm_event_wait() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(r[i] == i * 2);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2; });
 }
 
 void test_usm_queue_wait() {
@@ -239,9 +231,7 @@ void test_usm_queue_wait() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(r[i] == i * 2);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2; });
 }
 
 void test_buffer_host_accessor() {
@@ -277,9 +267,7 @@ void test_buffer_host_accessor() {
       {
         auto hostAccR = bufR.get_host_access(sycl::read_only);  // Copy-to-host
 
-        for (int i = 0; i < dataSize; ++i) {
-          SYCLACADEMY_ASSERT(hostAccR[i] == i * 2);
-        }
+        SYCLACADEMY_ASSERT_EQUAL(hostAccR, [](size_t i) { return i * 2; });
       }
 
     }  // Copy-back

--- a/Code_Exercises/Asynchronous_Execution/source.cpp
+++ b/Code_Exercises/Asynchronous_Execution/source.cpp
@@ -48,12 +48,12 @@
 
 void test_usm() {
   // Use your code from the "Data Parallelism" exercise to start
-  SYCLACADEMY_ASSERT(true);
+  SYCLACADEMY_ASSERT_EQUAL(/*output data*/ 0, /*expected data*/ 0);
 }
 
 void test_buffer() {
   // Use your code from the "Data Parallelism" exercise to start
-  SYCLACADEMY_ASSERT(true);
+  SYCLACADEMY_ASSERT_EQUAL(/*output data*/ 0, /*expected data*/ 0);
 }
 
 int main() {

--- a/Code_Exercises/Data_Parallelism/solution.cpp
+++ b/Code_Exercises/Data_Parallelism/solution.cpp
@@ -48,7 +48,5 @@ int main() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(r[i] == static_cast<float>(i) * 2.0f);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2.0f; });
 }

--- a/Code_Exercises/Data_Parallelism/source.cpp
+++ b/Code_Exercises/Data_Parallelism/source.cpp
@@ -56,7 +56,5 @@ int main() {
     r[i] = a[i] + b[i];
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(r[i] == static_cast<float>(i) * 2.0f);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2.0f; });
 }

--- a/Code_Exercises/Data_and_Dependencies/solution.cpp
+++ b/Code_Exercises/Data_and_Dependencies/solution.cpp
@@ -89,9 +89,7 @@ void test_buffer() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(out[i] == i * 2.0f);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(out, [](size_t i) { return i * 2.0f; });
 }
 
 void test_usm() {
@@ -156,9 +154,7 @@ void test_usm() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(out[i] == i * 2.0f);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(out, [](size_t i) { return i * 2.0f; });
 }
 
 int main() {

--- a/Code_Exercises/Data_and_Dependencies/source.cpp
+++ b/Code_Exercises/Data_and_Dependencies/source.cpp
@@ -87,7 +87,5 @@ int main() {
     out[i] = inB[i] + inC[i];
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(out[i] == i * 2.0f);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(out, [](size_t i) { return i * 2.0f; });
 }

--- a/Code_Exercises/Device_Discovery/solution.cpp
+++ b/Code_Exercises/Device_Discovery/solution.cpp
@@ -68,5 +68,5 @@ int main() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  SYCLACADEMY_ASSERT(r == 42);
+  SYCLACADEMY_ASSERT_EQUAL(r, 42);
 }

--- a/Code_Exercises/Device_Discovery/source.cpp
+++ b/Code_Exercises/Device_Discovery/source.cpp
@@ -83,5 +83,5 @@ int main() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  SYCLACADEMY_ASSERT(r == 42);
+  SYCLACADEMY_ASSERT_EQUAL(r, 42);
 }

--- a/Code_Exercises/In_Order_Queue/solution_vector_add.cpp
+++ b/Code_Exercises/In_Order_Queue/solution_vector_add.cpp
@@ -89,9 +89,7 @@ void test_buffer() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(out[i] == i * 2.0f);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(out, [](size_t i) { return i * 2.0f; });
 }
 
 void test_usm() {
@@ -160,9 +158,7 @@ void test_usm() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(out[i] == i * 2.0f);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(out, [](size_t i) { return i * 2.0f; });
 }
 
 int main() {

--- a/Code_Exercises/In_Order_Queue/source_vector_add.cpp
+++ b/Code_Exercises/In_Order_Queue/source_vector_add.cpp
@@ -59,5 +59,5 @@
 
 int main() {
   // Use the "Data and Dependencies" exercise solution to start
-  SYCLACADEMY_ASSERT(true);
+  SYCLACADEMY_ASSERT_EQUAL(/*output data*/ 0, /*expected data*/ 0);
 }

--- a/Code_Exercises/Managing_Data/solution.cpp
+++ b/Code_Exercises/Managing_Data/solution.cpp
@@ -40,7 +40,7 @@ void test_usm() {
   sycl::free(dev_B, defaultQueue);
   sycl::free(dev_R, defaultQueue);
 
-  SYCLACADEMY_ASSERT(r == 42);
+  SYCLACADEMY_ASSERT_EQUAL(r, 42);
 }
 
 void test_buffer() {
@@ -65,7 +65,7 @@ void test_buffer() {
         .wait();
   }
 
-  SYCLACADEMY_ASSERT(r == 42);
+  SYCLACADEMY_ASSERT_EQUAL(r, 42);
 }
 
 int main() {

--- a/Code_Exercises/Managing_Data/source.cpp
+++ b/Code_Exercises/Managing_Data/source.cpp
@@ -53,7 +53,7 @@ void test_usm() {
   // Task: Compute a+b on the SYCL device using USM
   r = a + b;
 
-  SYCLACADEMY_ASSERT(r == 42);
+  SYCLACADEMY_ASSERT_EQUAL(r, 42);
 }
 
 void test_buffer() {
@@ -63,7 +63,7 @@ void test_buffer() {
   // accessor memory model
   r = a + b;
 
-  SYCLACADEMY_ASSERT(r == 42);
+  SYCLACADEMY_ASSERT_EQUAL(r, 42);
 }
 
 int main() {

--- a/Code_Exercises/Matrix_Transpose/solution.cpp
+++ b/Code_Exercises/Matrix_Transpose/solution.cpp
@@ -139,7 +139,5 @@ int main() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (auto i = 0; i < N * N; ++i) {
-    SYCLACADEMY_ASSERT(A_T[i] == A_T_comparison[i]);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(A_T, A_T_comparison);
 }

--- a/Code_Exercises/Matrix_Transpose/source.cpp
+++ b/Code_Exercises/Matrix_Transpose/source.cpp
@@ -82,7 +82,5 @@ int main() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (auto i = 0; i < N * N; ++i) {
-    SYCLACADEMY_ASSERT(A_T[i] == A_T_comparison[i]);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(A_T, A_T_comparison);
 }

--- a/Code_Exercises/Multiple_Devices/solution.cpp
+++ b/Code_Exercises/Multiple_Devices/solution.cpp
@@ -88,7 +88,5 @@ int main() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(r[i] == static_cast<float>(i) * 2.0f);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2.0f; });
 }

--- a/Code_Exercises/Multiple_Devices/source.cpp
+++ b/Code_Exercises/Multiple_Devices/source.cpp
@@ -71,7 +71,5 @@ int main() {
     r[dataSizeFirst + i] = a[dataSizeFirst + i] + b[dataSizeFirst + i];
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(r[i] == static_cast<float>(i) * 2.0f);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2.0f; });
 }

--- a/Code_Exercises/ND_Range_Kernel/solution.cpp
+++ b/Code_Exercises/ND_Range_Kernel/solution.cpp
@@ -49,9 +49,7 @@ void test_item() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(r[i] == i * 2);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2; });
 }
 
 void test_nd_item() {
@@ -91,9 +89,7 @@ void test_nd_item() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(r[i] == i * 2);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2; });
 }
 
 int main() {

--- a/Code_Exercises/ND_Range_Kernel/source.cpp
+++ b/Code_Exercises/ND_Range_Kernel/source.cpp
@@ -71,7 +71,5 @@ int main() {
     r[i] = a[i] + b[i];
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(r[i] == i * 2);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2; });
 }

--- a/Code_Exercises/Using_USM/solution.cpp
+++ b/Code_Exercises/Using_USM/solution.cpp
@@ -62,7 +62,5 @@ int main() {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(r[i] == i * 2);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2.0f; });
 }

--- a/Code_Exercises/Using_USM/source.cpp
+++ b/Code_Exercises/Using_USM/source.cpp
@@ -26,7 +26,5 @@ int main() {
     r[i] = a[i] + b[i];
   }
 
-  for (int i = 0; i < dataSize; ++i) {
-    SYCLACADEMY_ASSERT(r[i] == i * 2);
-  }
+  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2.0f; });
 }

--- a/Code_Exercises/helpers.hpp
+++ b/Code_Exercises/helpers.hpp
@@ -17,20 +17,22 @@
 #ifndef __SYCL_DEVICE_ONLY__
 #include <cstdio>   // fprintf
 #include <cstdlib>  // abort
-#define SYCLACADEMY_ASSERT(cond)                                              \
-  if (!(cond)) {                                                              \
-    std::fprintf(stderr, "[FAILURE] %s failed in %s:%d:%s\nExiting\n", #cond, \
-                 __BASE_FILE__, __LINE__, __FUNCTION__);                      \
-    std::abort();                                                             \
-  } else {                                                                    \
-    std::printf("[SUCCESS] Test passed\n");                                   \
-  }
+#define SYCLACADEMY_ASSERT(cond)                                         \
+  do {                                                                   \
+    if (!(cond)) {                                                       \
+      std::fprintf(stderr, "[FAILURE] %s failed in %s:%d:%s\nExiting\n", \
+                   #cond, __BASE_FILE__, __LINE__, __FUNCTION__);        \
+      std::abort();                                                      \
+    } else {                                                             \
+      std::printf("[SUCCESS] Test passed\n");                            \
+    }                                                                    \
+  } while (false)
 #else
-#define SYCLACADEMY_ASSERT(cond) void(0);
+#define SYCLACADEMY_ASSERT(cond) void(0)
 #endif
 
 #define SYCLACADEMY_ASSERT_EQUAL(lhs, rhs) \
-  SYCLACADEMY_ASSERT(SYCLAcademy::equal(lhs, rhs));
+  SYCLACADEMY_ASSERT(SYCLAcademy::equal(lhs, rhs))
 
 namespace SYCLAcademy {
 

--- a/Code_Exercises/helpers.hpp
+++ b/Code_Exercises/helpers.hpp
@@ -11,16 +11,106 @@
 #pragma once
 
 #include <cstddef>  // for size_t
+#include <type_traits>
+#include <utility>
 
 #ifndef __SYCL_DEVICE_ONLY__
 #include <cstdio>   // fprintf
 #include <cstdlib>  // abort
-#define SYCLACADEMY_ASSERT(cond)                                    \
-  if (!(cond)) {                                                    \
-    std::fprintf(stderr, "%s failed in %s:%d:%s\nExiting\n", #cond, \
-                 __BASE_FILE__, __LINE__, __FUNCTION__);            \
-    std::abort();                                                   \
+#define SYCLACADEMY_ASSERT(cond)                                              \
+  if (!(cond)) {                                                              \
+    std::fprintf(stderr, "[FAILURE] %s failed in %s:%d:%s\nExiting\n", #cond, \
+                 __BASE_FILE__, __LINE__, __FUNCTION__);                      \
+    std::abort();                                                             \
+  } else {                                                                    \
+    std::printf("[SUCCESS] Test passed\n");                                   \
   }
 #else
 #define SYCLACADEMY_ASSERT(cond) void(0);
 #endif
+
+#define SYCLACADEMY_ASSERT_EQUAL(lhs, rhs) \
+  SYCLACADEMY_ASSERT(SYCLAcademy::equal(lhs, rhs));
+
+namespace SYCLAcademy {
+
+template <typename, typename = void, typename = void>
+struct is_vector : std::false_type {};
+
+template <typename T>
+struct is_vector<T, std::void_t<decltype(std::declval<T>()[size_t{}])>,
+                 std::void_t<decltype(std::declval<T>().size())> >
+    : std::true_type {};
+
+template <typename T>
+constexpr bool is_vector_v = is_vector<T>::value;
+
+template <typename T>
+constexpr size_t get_size(T&& container) {
+  using TT = std::remove_reference_t<T>;
+  if constexpr (std::is_array_v<TT>) {
+    return std::extent_v<TT>;
+  } else if constexpr (is_vector_v<TT>) {
+    return container.size();
+  }
+  return 0;
+}
+
+/**
+ * @brief Generic equality comparison
+ *
+ * Pointer types are not allowed.
+ *
+ * @param lhs can be a fundamental type, an object, an array or a vector-like
+ * type (has operator[] and method size())
+ * @param rhs allowed types depend on lhs type; it can be always a fundamental
+ * type or an object; if lhs is an array or vector-like type then it can be an
+ * array or vector-like type (for element-wise comparison) or a lambda taking
+ * size_t index as parameter (for element-wise comparison to the return value
+ * of lambda(index))
+ */
+template <typename T, typename U>
+constexpr bool equal(T&& lhs, U&& rhs) {
+  using TT = std::remove_reference_t<T>;
+  using UU = std::remove_reference_t<U>;
+  static_assert(!std::is_pointer_v<TT> && !std::is_pointer_v<UU>);
+  if constexpr (std::is_array_v<TT> || is_vector_v<TT>) {
+    const size_t lhs_size{get_size(std::forward<T>(lhs))};
+    if constexpr (std::is_array_v<UU> || is_vector_v<UU>) {
+      //
+      // Compare array/vector to array/vector element-wise
+      //
+      const size_t rhs_size{get_size(std::forward<U>(rhs))};
+      if (lhs_size < 1 || lhs_size != rhs_size) {
+        return false;
+      }
+      for (size_t i{0}; i < lhs_size; ++i) {
+        if (lhs[i] != rhs[i]) return false;
+      }
+      return true;
+    } else if constexpr (std::is_invocable_v<UU, size_t>) {
+      //
+      // Compare array/vector to lambda(index) element-wise
+      //
+      for (size_t i{0}; i < lhs_size; ++i) {
+        if (lhs[i] != rhs(i)) return false;
+      }
+      return true;
+    } else {
+      //
+      // Compare all elements of an array/vector to a single value
+      //
+      for (size_t i{0}; i < lhs_size; ++i) {
+        if (lhs[i] != rhs) return false;
+      }
+      return true;
+    }
+  } else {
+    //
+    // Single value comparison
+    //
+    static_assert(!std::is_array_v<UU> && !is_vector_v<UU>);
+    return lhs == rhs;
+  }
+}
+}  // namespace SYCLAcademy


### PR DESCRIPTION
In a recent workshop participants were repeatedly confused by the lack of output in the exercises and kept asking if no output means success. Make the `SYCLACADEMY_ASSERT` macro print `[SUCCESS] Test passed` on success and `[FAILURE] ...` with the same message as before on failure.

There was a lot of code like:
```cpp
for (int i = 0; i < 1024; ++i) {
  SYCLACADEMY_ASSERT(out[i] == i * 4.0f);
}
```
It would be silly for the program to print 1024 lines of the same success message, so replace this kind of comparison with a new `SYCL_ACADEMY_ASSERT_EQUAL` macro which implements a generic comparison function supporting element-wise comparison of arrays/vectors and only calls the `SYCLACADEMY_ASSERT` once, and therefore prints SUCCESS/FAILURE once.