### PR TITLE
Exercise buffers are declared as int instead of floats

### DIFF
--- a/Code_Exercises/Data_and_Dependencies/solution.cpp
+++ b/Code_Exercises/Data_and_Dependencies/solution.cpp
@@ -95,7 +95,7 @@ void test_buffer() {
 void test_usm() {
   constexpr size_t dataSize = 1024;
 
-  int inA[dataSize], inB[dataSize], inC[dataSize], out[dataSize];
+  float inA[dataSize], inB[dataSize], inC[dataSize], out[dataSize];
   for (int i = 0; i < dataSize; ++i) {
     inA[i] = static_cast<float>(i);
     inB[i] = static_cast<float>(i);

--- a/Code_Exercises/Data_and_Dependencies/source.cpp
+++ b/Code_Exercises/Data_and_Dependencies/source.cpp
@@ -56,7 +56,7 @@
 int main() {
   constexpr size_t dataSize = 1024;
 
-  int inA[dataSize], inB[dataSize], inC[dataSize], out[dataSize];
+  float inA[dataSize], inB[dataSize], inC[dataSize], out[dataSize];
   for (int i = 0; i < dataSize; ++i) {
     inA[i] = static_cast<float>(i);
     inB[i] = static_cast<float>(i);


### PR DESCRIPTION
I've been solving exercise 5 and my code was failing: 
```C++
int main() {
  constexpr size_t dataSize = 1024;

  int inA[dataSize], inB[dataSize], inC[dataSize], out[dataSize];
  for (int i = 0; i < dataSize; ++i) {
    inA[i] = static_cast<float>(i);
    inB[i] = static_cast<float>(i);
    inC[i] = static_cast<float>(i);
    out[i] = 0.0f;
  }
  auto q = sycl::queue{};

  // Task: Run these kernels on the SYCL device, respecting the dependencies
  // as shown in the README

  auto bufA = sycl::buffer{inA, sycl::range{dataSize}};
  // Kernel A
  auto e1 = q.submit([&](sycl::handler& cgh) {
    sycl::accessor accA{bufA, cgh, sycl::read_write};
    cgh.parallel_for(sycl::range{dataSize},
                     [=](sycl::id<1> idx) { accA[idx] = accA[idx] * 2.0f; });
  });

  auto devPB = sycl::malloc_device<float>(dataSize, q);
  auto eb_copy = q.memcpy(devPB, inB, sizeof(float) * dataSize);

  // Kernel B
  auto e2 = q.submit([&](sycl::handler& cgh) {
    cgh.depends_on({e1, eb_copy});
    sycl::accessor accA{bufA, cgh, sycl::read_only};
    cgh.parallel_for(sycl::range{dataSize},
                     [=](sycl::id<1> idx) { devPB[idx] += accA[idx]; });
  });

  auto finish_e2 = q.memcpy(inB, devPB, sizeof(float) * dataSize, e2);
 
  auto bufC = sycl::buffer{inC, sycl::range{dataSize}};

  //Kernel C
  auto e3 = q.submit([&](sycl::handler& cgh) {
    cgh.depends_on(finish_e2);
    sycl::accessor accA{bufA, cgh, sycl::read_only};
    sycl::accessor accC{bufC, cgh, sycl::read_write};
    cgh.parallel_for(sycl::range{dataSize},
                     [=](sycl::id<1> idx) { accC[idx] -= accA[idx]; });
  });
  e3.wait();
  // for (int i = 0; i < dataSize; ++i) {
  //   inC[i] -= inA[i];
  // }

  // Kernel D
  for (int i = 0; i < dataSize; ++i) {
    out[i] = inB[i] + inC[i];
  }

  sycl::free(devPB, q);
  SYCLACADEMY_ASSERT_EQUAL(out, [](size_t i) { return i * 2.0f; });
}
```
Noticed line `int inA[dataSize], inB[dataSize], inC[dataSize], out[dataSize];` declares the data as int instead of float and changing it fixed the issue.