### PR TITLE
FastTrack code and slides update for ISC25 

### DIFF
--- a/Code_Exercises/Asynchronous_Execution/solution.cpp
+++ b/Code_Exercises/Asynchronous_Execution/solution.cpp
@@ -9,23 +9,10 @@
 */
 
 #include <sycl/sycl.hpp>
-
 #include "../helpers.hpp"
+using namespace sycl;
 
-class vector_add_1;
-class vector_add_2;
-class vector_add_3;
-class vector_add_4;
-class vector_add_5;
-class vector_add_6;
 
-int usm_selector(const sycl::device& dev) {
-  if (dev.has(sycl::aspect::usm_device_allocations)) {
-    if (dev.has(sycl::aspect::gpu)) return 2;
-    return 1;
-  }
-  return -1;
-}
 
 void test_buffer_event_wait() {
   constexpr size_t dataSize = 1024;
@@ -38,26 +25,26 @@ void test_buffer_event_wait() {
   }
 
   try {
-    auto defaultQueue = sycl::queue{};
+    queue defaultQueue = queue{};
 
-    auto bufA = sycl::buffer{a, sycl::range{dataSize}};
-    auto bufB = sycl::buffer{b, sycl::range{dataSize}};
-    auto bufR = sycl::buffer{r, sycl::range{dataSize}};
+    buffer bufA = buffer{a, range{dataSize}};
+    buffer bufB = buffer{b, range{dataSize}};
+    buffer bufR = buffer{r, range{dataSize}};
 
     defaultQueue
-        .submit([&](sycl::handler& cgh) {
-          auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
-          auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
-          auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
+        .submit([&](handler& cgh) {
+          accessor accA = accessor{bufA, cgh, read_only};
+          accessor accB = accessor{bufB, cgh, read_only};
+          accessor accR = accessor{bufR, cgh, write_only};
 
-          cgh.parallel_for<vector_add_1>(
-              sycl::range{dataSize},
-              [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
+          cgh.parallel_for(
+              range{dataSize},
+              [=](id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
         })
         .wait();  // Synchronize
 
     defaultQueue.throw_asynchronous();
-  } catch (const sycl::exception& e) {  // Copy back
+  } catch (const exception& e) {  // Copy back
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 
@@ -75,20 +62,20 @@ void test_buffer_queue_wait() {
   }
 
   try {
-    auto defaultQueue = sycl::queue{};
+    queue defaultQueue = queue{};
 
-    auto bufA = sycl::buffer{a, sycl::range{dataSize}};
-    auto bufB = sycl::buffer{b, sycl::range{dataSize}};
-    auto bufR = sycl::buffer{r, sycl::range{dataSize}};
+    buffer bufA = buffer{a, range{dataSize}};
+    buffer bufB = buffer{b, range{dataSize}};
+    buffer bufR = buffer{r, range{dataSize}};
 
-    defaultQueue.submit([&](sycl::handler& cgh) {
-      auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
-      auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
-      auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
+    defaultQueue.submit([&](handler& cgh) {
+      accessor accA = accessor{bufA, cgh, read_only};
+      accessor accB = accessor{bufB, cgh, read_only};
+      accessor accR = accessor{bufR, cgh, write_only};
 
-      cgh.parallel_for<vector_add_2>(
-          sycl::range{dataSize},
-          [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
+      cgh.parallel_for(
+          range{dataSize},
+          [=](id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
     });
 
     defaultQueue.wait_and_throw();      // Synchronize
@@ -110,21 +97,21 @@ void test_buffer_buffer_destruction() {
   }
 
   try {
-    auto defaultQueue = sycl::queue{};
+    queue defaultQueue = queue{};
 
     {
-      auto bufA = sycl::buffer{a, sycl::range{dataSize}};
-      auto bufB = sycl::buffer{b, sycl::range{dataSize}};
-      auto bufR = sycl::buffer{r, sycl::range{dataSize}};
+      buffer bufA = buffer{a, range{dataSize}};
+      buffer bufB = buffer{b, range{dataSize}};
+      buffer bufR = buffer{r, range{dataSize}};
 
       defaultQueue.submit([&](sycl::handler& cgh) {
-        auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
-        auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
-        auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
+        accessor accA = accessor{bufA, cgh, read_only};
+        accessor accB = accessor{bufB, cgh, read_only};
+        accessor accR = accessor{bufR, cgh, write_only};
 
-        cgh.parallel_for<vector_add_3>(
-            sycl::range{dataSize},
-            [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
+        cgh.parallel_for(
+            range{dataSize},
+            [=](id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
       });
     }  // Synchronize and copy-back
 
@@ -136,103 +123,6 @@ void test_buffer_buffer_destruction() {
   SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2; });
 }
 
-void test_usm_event_wait() {
-  constexpr size_t dataSize = 1024;
-
-  float a[dataSize], b[dataSize], r[dataSize];
-  for (int i = 0; i < dataSize; ++i) {
-    a[i] = static_cast<float>(i);
-    b[i] = static_cast<float>(i);
-    r[i] = 0.0f;
-  }
-
-  try {
-    auto usmQueue = sycl::queue{usm_selector};
-
-    auto devicePtrA = sycl::malloc_device<float>(dataSize, usmQueue);
-    auto devicePtrB = sycl::malloc_device<float>(dataSize, usmQueue);
-    auto devicePtrR = sycl::malloc_device<float>(dataSize, usmQueue);
-
-    usmQueue.memcpy(devicePtrA, a,
-                    sizeof(float) * dataSize)
-        .wait();  // Synchronize
-    usmQueue.memcpy(devicePtrB, b,
-                    sizeof(float) * dataSize)
-        .wait();  // Synchronize
-
-    usmQueue
-        .parallel_for<vector_add_4>(sycl::range{dataSize},
-                                    [=](sycl::id<1> idx) {
-                                      auto globalId = idx[0];
-                                      devicePtrR[globalId] =
-                                          devicePtrA[globalId] +
-                                          devicePtrB[globalId];
-                                    })
-        .wait();  // Synchronize
-
-    usmQueue.memcpy(r, devicePtrR,
-                    sizeof(float) * dataSize)
-        .wait();  // Synchronize and copy-back
-
-    sycl::free(devicePtrA, usmQueue);
-    sycl::free(devicePtrB, usmQueue);
-    sycl::free(devicePtrR, usmQueue);
-
-    usmQueue.throw_asynchronous();
-  } catch (const sycl::exception& e) {
-    std::cout << "Exception caught: " << e.what() << std::endl;
-  }
-
-  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2; });
-}
-
-void test_usm_queue_wait() {
-  constexpr size_t dataSize = 1024;
-
-  float a[dataSize], b[dataSize], r[dataSize];
-  for (int i = 0; i < dataSize; ++i) {
-    a[i] = static_cast<float>(i);
-    b[i] = static_cast<float>(i);
-    r[i] = 0.0f;
-  }
-
-  try {
-    auto usmQueue = sycl::queue{usm_selector};
-
-    auto devicePtrA = sycl::malloc_device<float>(dataSize, usmQueue);
-    auto devicePtrB = sycl::malloc_device<float>(dataSize, usmQueue);
-    auto devicePtrR = sycl::malloc_device<float>(dataSize, usmQueue);
-
-    usmQueue.memcpy(devicePtrA, a, sizeof(float) * dataSize);
-    usmQueue.memcpy(devicePtrB, b, sizeof(float) * dataSize);
-
-    usmQueue.wait();  // Synchronize
-
-    usmQueue.parallel_for<vector_add_5>(
-        sycl::range{dataSize}, [=](sycl::id<1> idx) {
-          auto globalId = idx[0];
-          devicePtrR[globalId] = devicePtrA[globalId] + devicePtrB[globalId];
-        });
-
-    usmQueue.wait();  // Synchronize
-
-    usmQueue.memcpy(r, devicePtrR,
-                    sizeof(float) * dataSize)
-        .wait();  // Copy-back
-
-    usmQueue.wait();  // Synchronize
-
-    sycl::free(devicePtrA, usmQueue);
-    sycl::free(devicePtrB, usmQueue);
-    sycl::free(devicePtrR, usmQueue);
-
-    usmQueue.throw_asynchronous();
-  } catch (const sycl::exception& e) {
-    std::cout << "Exception caught: " << e.what() << std::endl;
-  }
-
-  SYCLACADEMY_ASSERT_EQUAL(r, [](size_t i) { return i * 2; });
-}
 
 void test_buffer_host_accessor() {
   constexpr size_t dataSize = 1024;
@@ -245,27 +135,27 @@ void test_buffer_host_accessor() {
   }
 
   try {
-    auto defaultQueue = sycl::queue{};
+    queue defaultQueue = queue{};
 
     {
-      auto bufA = sycl::buffer{a, sycl::range{dataSize}};
-      auto bufB = sycl::buffer{b, sycl::range{dataSize}};
-      auto bufR = sycl::buffer{r, sycl::range{dataSize}};
+      buffer bufA = buffer{a, range{dataSize}};
+      buffer bufB = buffer{b, range{dataSize}};
+      buffer bufR = buffer{r, range{dataSize}};
 
       defaultQueue.submit([&](sycl::handler& cgh) {
-        auto accA = sycl::accessor{bufA, cgh, sycl::read_only};
-        auto accB = sycl::accessor{bufB, cgh, sycl::read_only};
-        auto accR = sycl::accessor{bufR, cgh, sycl::write_only};
+        accessor accA = accessor{bufA, cgh, read_only};
+        accessor accB = accessor{bufB, cgh, read_only};
+        accessor accR = accessor{bufR, cgh, write_only};
 
-        cgh.parallel_for<vector_add_6>(
-            sycl::range{dataSize},
+        cgh.parallel_for(
+            range{dataSize},
             [=](sycl::id<1> idx) { accR[idx] = accA[idx] + accB[idx]; });
       });
 
       defaultQueue.wait();  // Synchronize
 
       {
-        auto hostAccR = bufR.get_host_access(sycl::read_only);  // Copy-to-host
+        host_accessor hostAccR = bufR.get_host_access(read_only);  // Copy-to-host
 
         SYCLACADEMY_ASSERT_EQUAL(hostAccR, [](size_t i) { return i * 2; });
       }
@@ -273,7 +163,7 @@ void test_buffer_host_accessor() {
     }  // Copy-back
 
     defaultQueue.throw_asynchronous();
-  } catch (const sycl::exception& e) {
+  } catch (const exception& e) {
     std::cout << "Exception caught: " << e.what() << std::endl;
   }
 }
@@ -282,7 +172,5 @@ int main() {
   test_buffer_event_wait();
   test_buffer_queue_wait();
   test_buffer_buffer_destruction();
-  test_usm_event_wait();
-  test_usm_queue_wait();
   test_buffer_host_accessor();
 }

--- a/Code_Exercises/Asynchronous_Execution/source.cpp
+++ b/Code_Exercises/Asynchronous_Execution/source.cpp
@@ -11,16 +11,10 @@
  * ~~~~~~~~~~~~~~~~~~~~
  *
  * // Default construct a queue
- * auto q = sycl::queue{};
+ * sycl::queue queue q = sycl::queue{};
  *
  * // Declare a buffer pointing to ptr
- * auto buf = sycl::buffer{ptr, sycl::range{n}};
- *
- * // Do a USM malloc_device
- * auto ptr = sycl::malloc_device<T>(n, q);
- *
- * // Do a USM memcpy
- * q.memcpy(dst_ptr, src_ptr, sizeof(T)*n);
+ * sycl::buffer buf = sycl::buffer{ptr, sycl::range{n}};
  *
  * // Wait on a queue
  * q.wait();
@@ -33,10 +27,10 @@
  *
  * // Within the command group you can
  * //    1. Declare an accessor to a buffer
- *          auto read_write_acc = sycl::accessor{buf, cgh};
- *          auto read_acc = sycl::accessor{buf, cgh, sycl::read_only};
- *          auto write_acc = sycl::accessor{buf, cgh, sycl::write_only};
- *          auto no_init_acc = sycl::accessor{buf, cgh, sycl::no_init};
+ *          accessor read_write_acc = sycl::accessor{buf, cgh};
+ *          accessor read_acc = sycl::accessor{buf, cgh, sycl::read_only};
+ *          accessor write_acc = sycl::accessor{buf, cgh, sycl::write_only};
+ *          accessor no_init_acc = sycl::accessor{buf, cgh, sycl::no_init};
  * //    2. Enqueue a parallel for:
  *              cgh.parallel_for<class mykernel>(sycl::range{n},
  *                    [=](sycl::id<1> i) { // Do something });
@@ -46,17 +40,11 @@
 
 #include "../helpers.hpp"
 
-void test_usm() {
-  // Use your code from the "Data Parallelism" exercise to start
-  SYCLACADEMY_ASSERT_EQUAL(/*output data*/ 0, /*expected data*/ 0);
-}
-
 void test_buffer() {
   // Use your code from the "Data Parallelism" exercise to start
   SYCLACADEMY_ASSERT_EQUAL(/*output data*/ 0, /*expected data*/ 0);
 }
 
 int main() {
-  test_usm();
   test_buffer();
 }

--- a/Lesson_Materials/Fast_Track/index.html
+++ b/Lesson_Materials/Fast_Track/index.html
@@ -585,8 +585,8 @@ handler.parallel_for(range, func);
 					<div class="container" data-markdown>
             * Goal: Learn to use different techniques for synchronizing commands and data
             * The exercise README is in the "Code_Exercises/Asynchronous_Execution" folder
-	    * In "syclacademy/tree/isc25" page you can find links to the Compiler Explorer code
-            * Follow the guidelines in the README and comments in the source.cpp file or equivalent CE page
+	    * In the "syclacademy/tree/isc25" page you can find links to the Compiler Explorer codes
+            * Follow the guidelines in the README and comments in the source.cpp file or equivalent CE code
 	    * There is a solution file in the repo and CE link, but only use it if you need to
 					</div>
 				</section>

--- a/Lesson_Materials/Fast_Track/index.html
+++ b/Lesson_Materials/Fast_Track/index.html
@@ -105,7 +105,7 @@
               * Dependency management and scheduling
 					</div>
 				</section>
-				<!--Slide 6-->
+				<!--Slide 6 REMOVED for ISC25
 				<section>
 					<div class="hbox" data-markdown>
 						#### Image convolution sample application
@@ -119,7 +119,8 @@
 						* A lot of data must be passed through the GPU to process an image, particularly if the image is very high resolution.
 					</div>
 				</section>
-				<!--Slide 7-->
+				-->
+				<!--Slide 7 REMOVED for ISC25
 				<section>
 					<div class="hbox" data-markdown>
 						#### Image convolution definition
@@ -136,6 +137,7 @@
 						</div>
 					</div>
 				</section>
+				-->
         <!--Slide 8-->
 				<section>
 					<div class="hbox" data-markdown>
@@ -587,7 +589,7 @@ handler.parallel_for(range, func);
 	    * There is a solution file but only use it if you need to
 					</div>
 				</section>
-				<!--Slide 35-->
+				<!--Slide 35 REMOVED
 				<section>
 					<div class="hbox" data-markdown>
 						#### Image convolution example
@@ -596,7 +598,8 @@ handler.parallel_for(range, func);
 						![SYCL](../common-revealjs/images/image_convolution_example.png "SYCL")
 					</div>
 				</section>
-				<!--Slide 36-->
+				-->
+				<!--Slide 36 REMOVED
 				<section>
 					<div class="hbox" data-markdown>
 						#### Image convolution data flow
@@ -613,7 +616,8 @@ handler.parallel_for(range, func);
 						</div>
 					</div>
 				</section>
-				<!--Slide 37-->
+				-->
+				<!--Slide 37
 				<section>
 					<div class="hbox" data-markdown>
 						#### Gaussian Blur
@@ -628,7 +632,8 @@ handler.parallel_for(range, func);
             * A dscrete convolution, in other words
 					</div>
 				</section>
-				<!--Slide 38-->
+				-->
+				<!--Slide 38
 				<section>
 					<div class="hbox" data-markdown>
 						#### Walkthrough
@@ -638,7 +643,8 @@ handler.parallel_for(range, func);
             * Solution available in `Code_Exercises/Functors/solution.cpp`
 					</div>
 				</section>
-				<!--Slide 39-->
+				-->
+				<!--Slide 39
 				<section>
 					<div class="hbox" data-markdown>
 						#### Reference image
@@ -654,7 +660,8 @@ handler.parallel_for(range, func);
 * The read and write functions can be found in `image_conv.h`.
 					</div>
 				</section>
-				<!--Slide 40-->
+				-->
+				<!--Slide 40
 				<section>
 					<div class="hbox" data-markdown>
 						#### Convolution filters
@@ -668,6 +675,7 @@ can be either `identity` or `blur` and a width.
 * The function can be found in `image_conv.h`
 					</div>
 				</section>
+				-->
 			</div>
 		</div>
 		<script src="../common-revealjs/js/reveal.js"></script>

--- a/Lesson_Materials/Fast_Track/index.html
+++ b/Lesson_Materials/Fast_Track/index.html
@@ -218,7 +218,7 @@ auto gpuDevice = device(gpu_selector_v);
 				<!--Slide 13-->
 				<section>
 					<div class="hbox" data-markdown>
-						#### In-of-order execution
+						#### In-order execution
 					</div>
 					<div class="container">
 						<div class="col" data-markdown>

--- a/Lesson_Materials/Fast_Track/index.html
+++ b/Lesson_Materials/Fast_Track/index.html
@@ -585,7 +585,7 @@ handler.parallel_for(range, func);
 					<div class="container" data-markdown>
             * Goal: Learn to use different techniques for synchronizing commands and data
             * The exercise README is in the "Code_Exercises/Asynchronous_Execution" folder
-	    * In https://github.com/codeplaysoftware/syclacademy/tree/isc25 you can find links to the Compiler Explorer (CE) reference page
+	    * In "syclacademy/tree/isc25" page you can find links to the Compiler Explorer code
             * Follow the guidelines in the README and comments in the source.cpp file or equivalent CE page
 	    * There is a solution file in the repo and CE link, but only use it if you need to
 					</div>

--- a/Lesson_Materials/Fast_Track/index.html
+++ b/Lesson_Materials/Fast_Track/index.html
@@ -583,10 +583,11 @@ handler.parallel_for(range, func);
 						#### First Exercise
 					</div>
 					<div class="container" data-markdown>
-            * Use Data Parallelism and write a SYCL kernel
-            * The exercise README is in the "Code_Exercises/Data_Parallelism" folder
-            * Follow the guidelines in the README and comments in the source.cpp file
-	    * There is a solution file but only use it if you need to
+            * Goal: Learn to use different techniques for synchronizing commands and data
+            * The exercise README is in the "Code_Exercises/Asynchronous_Execution" folder
+	    * In https://github.com/codeplaysoftware/syclacademy/tree/isc25 you can find links to the Compiler Explorer (CE) reference page
+            * Follow the guidelines in the README and comments in the source.cpp file or equivalent CE page
+	    * There is a solution file in the repo and CE link, but only use it if you need to
 					</div>
 				</section>
 				<!--Slide 35 REMOVED

--- a/README.md
+++ b/README.md
@@ -15,11 +15,11 @@ of the materials available in the main branch.
 The SYCL Academy curriculum is divided up into a number of short lessons
 consisting of slides for presenting the material and a more detailed write-up,
 each accompanied by a tutorial for getting hands on experience with the subject
-matter.
+matter. The code is available in both the repository and as a Compiler Explorer link.
 
-| Lesson | Title | Slides | Exercise | Source | Solution |
-|--------|-------|--------|----------|--------|----------|
-| 01 | A Fast Introduction to SYCL | [slides][lesson-1-slides] | [exercise][lesson-1-exercise] | [source][lesson-1-source] | [solution][lesson-1-solution] |
+| Lesson | Title | Slides | Exercise | Source | Solution | CompilerExplorer |
+|--------|-------|--------|----------|--------|----------|------------------|
+| 01 | A Fast Introduction to SYCL | [slides][lesson-1-slides] | [exercise][lesson-1-exercise] | [source][lesson-1-source] | [solution][lesson-1-solution] | [source][lesson-1-CEsource] [solution][lesson-1-CEsolution] |
 | 02 | ND Range Kernels and Concepts | [slides][lesson-2-slides] | [exercise][lesson-2-exercise] | [source][lesson-2-source] | [solution][lesson-2-solution] |
 | 03 | Data Flow with SYCL | [slides][lesson-3-slides] | [exercise][lesson-3-exercise] | [source][lesson-3-source] | [solution][lesson-3-solution] |
 | 04 | Recap and Further Learning | [slides][lesson-4-slides] | NA | NA | NA |
@@ -28,6 +28,9 @@ matter.
 [lesson-1-exercise]: ./Code_Exercises/Asynchronous_Execution/README.md
 [lesson-1-source]:   ./Code_Exercises/Asynchronous_Execution/source.cpp
 [lesson-1-solution]: ./Code_Exercises/Asynchronous_Execution/solution.cpp
+[lesson-1-CEsource]: https://godbolt.org/z/Mxb5zj6zW
+[lesson-1-CEsolution]: https://godbolt.org/z/Knn4ef9b4
+
 
 [lesson-2-slides]: ./Lesson_Materials/Data_Parallelism/
 [lesson-2-exercise]: ./Code_Exercises/Data_Parallelism/README.md

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@ consisting of slides for presenting the material and a more detailed write-up,
 each accompanied by a tutorial for getting hands on experience with the subject
 matter. The code is available in both the repository and as a Compiler Explorer link.
 
-| Lesson | Title | Slides | Exercise | Source | Solution | CompilerExplorer |
-|--------|-------|--------|----------|--------|----------|------------------|
-| 01 | A Fast Introduction to SYCL | [slides][lesson-1-slides] | [exercise][lesson-1-exercise] | [source][lesson-1-source] | [solution][lesson-1-solution] | [source][lesson-1-CEsource] [solution][lesson-1-CEsolution] |
-| 02 | ND Range Kernels and Concepts | [slides][lesson-2-slides] | [exercise][lesson-2-exercise] | [source][lesson-2-source] | [solution][lesson-2-solution] |
-| 03 | Data Flow with SYCL | [slides][lesson-3-slides] | [exercise][lesson-3-exercise] | [source][lesson-3-source] | [solution][lesson-3-solution] |
-| 04 | Recap and Further Learning | [slides][lesson-4-slides] | NA | NA | NA |
+| Lesson | Title | Slides | Exercise | Repository | CompilerExplorer |
+|--------|-------|--------|----------|------------|------------------|
+| 01 | A Fast Introduction to SYCL | [slides][lesson-1-slides] | [exercise][lesson-1-exercise] | [source][lesson-1-source]  [solution][lesson-1-solution] | [source][lesson-1-CEsource] [solution][lesson-1-CEsolution] |
+| 02 | ND Range Kernels and Concepts | [slides][lesson-2-slides] | [exercise][lesson-2-exercise] | [source][lesson-2-source]  [solution][lesson-2-solution] |
+| 03 | Data Flow with SYCL | [slides][lesson-3-slides] | [exercise][lesson-3-exercise] | [source][lesson-3-source]  [solution][lesson-3-solution] |
+| 04 | Recap and Further Learning | [slides][lesson-4-slides] | NA | NA |
 
 [lesson-1-slides]: ./Lesson_Materials/Fast_Track/
 [lesson-1-exercise]: ./Code_Exercises/Asynchronous_Execution/README.md


### PR DESCRIPTION
Updated source.cpp and solution.cpp for AsynchronousExecution:
- replaced auto with actual types
- added namespace sycl
- removed the two codes with USM

Added links to CompilerExplorer (CE) in README
- added two links for CE equivalent code for source.pp and solution.cpp
- the 2 codes have a quick check function that remove the need to have the helper function in another file, which does not seem to work properly in CE (at lesat, with SYCL)
- SYCL 2024.2.1

Slide update
- removed slides using convolution kernels
- added slide with CE reference
