### PR TITLE
[CMake] Enforce oneMath dependecy during configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ project (SYCLAcademy)
 option(SYCL_ACADEMY_USE_DPCPP "Configure to compile with Intel DPC++" OFF)
 option(SYCL_ACADEMY_USE_ADAPTIVECPP "Configure to compile with AdaptiveCpp" OFF)
 option(SYCL_ACADEMY_ENABLE_SOLUTIONS "Include solution source files in the project" OFF)
+option(SYCL_ACADEMY_ENABLE_ONEAPI_LESSONS "Include oneAPI lessons in the build" ${SYCL_ACADEMY_USE_DPCPP})
 
 # Variables
 

--- a/Code_Exercises/oneMath_gemm/CMakeLists.txt
+++ b/Code_Exercises/oneMath_gemm/CMakeLists.txt
@@ -8,6 +8,11 @@
   see <http://creativecommons.org/licenses/by-sa/4.0/>.
 ]]
 
+if (NOT SYCL_ACADEMY_ENABLE_ONEAPI_LESSONS)
+  message(STATUS "SYCL_ACADEMY_ENABLE_ONEAPI_LESSONS not set: disabling oneMath_gemm target")
+  return()
+endif()
+
 find_package(oneMath QUIET)
 if (NOT oneMath_FOUND)
   message(WARNING "oneMath not found: disabling oneMath_gemm target")

--- a/README.md
+++ b/README.md
@@ -97,7 +97,9 @@ may not match completely.
 ### oneMath
 
 The lessons in this table work with oneAPI, but might not work with other
-SYCL implementations.
+SYCL implementations. As a result they are only built by default when doing a
+DPC++ build of SYCL-Academy, but whether to build them can be controlled through the
+`SYCL_ACADEMY_ENABLE_ONEAPI_LESSIONS` CMake option.
 
 | Lesson | Title | Slides | Exercise | Source | Solution |
 |--------|-------|--------|----------|--------|----------|


### PR DESCRIPTION
Currently when trying to build the whole project using CMake without a oneMath install on the system, CMake will configure okay but then fail to find dependencies at build time.

A better used experience would be to try detect oneMath at CMake configure time, and then skip the `oneMath_gemm` target with a warning if oneMath isn't found.

If we really do want `oneMath` to be a dependency then this should be `find_package(oneMath REQUIRED)`, but that feels like it increases the barrier to entry for newcomers.