### PR TITLE
Fix invalid README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,8 +436,8 @@ cmake ../ "-GUnix Makefiles" -DSYCL_ACADEMY_USE_DPCPP=ON -DSYCL_ACADEMY_ENABLE_S
 
 [lesson-20-slides]: ./Lesson_Materials/More_SYCL_Features/
 [lesson-20-exercise]: ./Code_Exercises/More_SYCL_Features/README.md
-[lesson-20-source]:   ./Code_Exercises/More_SYCL_Features/source.cpp
-[lesson-20-solution]: ./Code_Exercises/More_SYCL_Features/solution.cpp
+[lesson-20-source]:   ./Code_Exercises/More_SYCL_Features
+[lesson-20-solution]: ./Code_Exercises/More_SYCL_Features
 
 [lesson-21-slides]: ./Lesson_Materials/Fast_Track/
 [lesson-21-exercise]: ./Code_Exercises/Functors/README.md

--- a/README.md
+++ b/README.md
@@ -446,5 +446,5 @@ cmake ../ "-GUnix Makefiles" -DSYCL_ACADEMY_USE_DPCPP=ON -DSYCL_ACADEMY_ENABLE_S
 
 [lesson-22-slides]: ./Lesson_Materials/oneMath_gemm/
 [lesson-22-exercise]: ./Code_Exercises/oneMath_gemm/README.md
-[lesson-22-source]:   ./Code_Exercises/oneMath_gemm/source.cpp
-[lesson-22-solution]: ./Code_Exercises/oneMath_gemm/solution.cpp
+[lesson-22-source]:   ./Code_Exercises/oneMath_gemm/source_onemath_usm_gemm.cpp
+[lesson-22-solution]: ./Code_Exercises/oneMath_gemm/solution_onemath_usm_gemm.cpp


### PR DESCRIPTION
The root README file contains a table of all the lessons with links to the lesson source and solution files, some of these links are broken as files named `source.cpp` and `solution.cpp` don't exist in the exercise directories.

### oneMath Lesson

The oneMath lesson features two versions of the source/solution files, one with USM and one with buffers with are distinguished in the filename. Therefore the `source.cpp` filename from the README table does not exist.

I've fixed the README link by picking the USM variant of the lesson source/solution to link to from the root README.

### More SYCL Features

The "More SYCL Features" contains 4 files `reduce_naive`/`reduce_group_algorithm`/`reduce_sycl_reduction`/`reduce_atomic.cpp` which don't fix neatly in the source+solution paradigm, so I've just made the readme links point to the folder itself.