### PR TITLE
Update slide wording on USM blocking behavior

### DIFF
--- a/Lesson_Materials/Fast_Track/index.html
+++ b/Lesson_Materials/Fast_Track/index.html
@@ -340,15 +340,15 @@ gpuQueue.submit([&](handler &cgh){
 void* malloc_device(size_t numBytes, const queue& syclQueue, const property_list &propList = {});
 
 template &lt;typename T&gt;
-T* malloc_device(size_t count, const queue& syclQueue,  const property_list &propList = {});
+T* malloc_device(size_t count, const queue& syclQueue, const property_list &propList = {});
 						</code></pre>
 					</div>
 					<div class="container" data-markdown>
 						* A USM device allocation is performed by calling one of the `malloc_device` functions.
 						* Both of these functions allocate the specified region of memory on the `device` associated with the specified `queue`.
 						* The pointer returned is only accessible in a kernel function running on that `device`.
-						* Synchronous exception if the device does not have aspect::usm_device_allocations
-						* This is a blocking operation.
+						* Synchronous exception if the device does not have `aspect::usm_device_allocations`.
+						* This is a synchronous operation.
 					</div>
 				</section>
 				<!--Slide 22-->
@@ -362,9 +362,9 @@ void free(void* ptr, queue& syclQueue);
 						</code></pre>
 					</div>
 					<div class="container" data-markdown>
-						* In order to prevent memory leaks USM device allocations must be free by calling the `free` function.
-						* The `queue` must be the same as was used to allocate the memory.
-						* This is a blocking operation.
+						* In order to prevent memory leaks USM device allocations must be freed by calling the `free` function.
+						* The `queue` is used to determine the SYCL context the allocation was made from. More details on context in "Multiple Devices" lesson.
+						* This is a synchronous operation.
 					</div>
 				</section>
 				<!--Slide 23-->

--- a/Lesson_Materials/Fast_Track/index.html
+++ b/Lesson_Materials/Fast_Track/index.html
@@ -363,7 +363,8 @@ void free(void* ptr, queue& syclQueue);
 					</div>
 					<div class="container" data-markdown>
 						* In order to prevent memory leaks USM device allocations must be freed by calling the `free` function.
-						* The `queue` is used to determine the SYCL context the allocation was made from. More details on context in "Multiple Devices" lesson.
+						* The `queue` should be the same as was used to allocate the memory.
+						* If a different `queue` is used, then it must match the context used to allocate the memory. More details on SYCL context in "Multiple Devices" lesson.
 						* This is a synchronous operation.
 					</div>
 				</section>

--- a/Lesson_Materials/Using_USM/index.html
+++ b/Lesson_Materials/Using_USM/index.html
@@ -105,8 +105,8 @@ T* malloc_device(size_t count, const queue& syclQueue,  const property_list &pro
 						* A USM device allocation is performed by calling one of the `malloc_device` functions.
 						* Both of these functions allocate the specified region of memory on the `device` associated with the specified `queue`.
 						* The pointer returned is only accessible in a kernel function running on that `device`.
-						* Synchronous exception if the device does not have aspect::usm_device_allocations
-						* This is a blocking operation.
+						* Synchronous exception if the device does not have `aspect::usm_device_allocations`.
+						* This is a synchronous operation where `syclQueue` provides the device and context.
 					</div>
 				</section>
 				<!--Slide 5-->
@@ -121,8 +121,8 @@ void free(void* ptr, queue& syclQueue);
 					</div>
 					<div class="container" data-markdown>
 						* In order to prevent memory leaks USM device allocations must be free by calling the `free` function.
-						* The `queue` must be the same as was used to allocate the memory.
-						* This is a blocking operation.
+						* This is a synchronous operation where `syclQueue` is used to determine the context.
+						* It is unspecified whether `free` is blocking or non-blocking - it should not be relied on for synchronization.
 					</div>
 				</section>
 				<!--Slide 6-->

--- a/Lesson_Materials/Using_USM/index.html
+++ b/Lesson_Materials/Using_USM/index.html
@@ -121,7 +121,8 @@ void free(void* ptr, queue& syclQueue);
 					</div>
 					<div class="container" data-markdown>
 						* In order to prevent memory leaks USM device allocations must be freed by calling the `free` function.
-						* The `queue` is used to determine the SYCL context the allocation was made from. More details on context in "Multiple Devices" lesson.
+						* The `queue` should be the same as was used to allocate the memory.
+						* If a different `queue` is used, then it must match the context used to allocate the memory. More details on SYCL context in "Multiple Devices" lesson.
 						* This is a synchronous operation.
 					</div>
 				</section>

--- a/Lesson_Materials/Using_USM/index.html
+++ b/Lesson_Materials/Using_USM/index.html
@@ -98,7 +98,7 @@
 void* malloc_device(size_t numBytes, const queue& syclQueue, const property_list &propList = {});
 
 template &lt;typename T&gt;
-T* malloc_device(size_t count, const queue& syclQueue,  const property_list &propList = {});
+T* malloc_device(size_t count, const queue& syclQueue, const property_list &propList = {});
 						</code></pre>
 					</div>
 					<div class="container" data-markdown>
@@ -106,7 +106,7 @@ T* malloc_device(size_t count, const queue& syclQueue,  const property_list &pro
 						* Both of these functions allocate the specified region of memory on the `device` associated with the specified `queue`.
 						* The pointer returned is only accessible in a kernel function running on that `device`.
 						* Synchronous exception if the device does not have `aspect::usm_device_allocations`.
-						* This is a synchronous operation where `syclQueue` provides the device and context.
+						* This is a synchronous operation.
 					</div>
 				</section>
 				<!--Slide 5-->
@@ -120,9 +120,9 @@ void free(void* ptr, queue& syclQueue);
 						</code></pre>
 					</div>
 					<div class="container" data-markdown>
-						* In order to prevent memory leaks USM device allocations must be free by calling the `free` function.
-						* This is a synchronous operation where `syclQueue` is used to determine the context.
-						* It is unspecified whether `free` is blocking or non-blocking - it should not be relied on for synchronization.
+						* In order to prevent memory leaks USM device allocations must be freed by calling the `free` function.
+						* The `queue` is used to determine the SYCL context the allocation was made from. More details on context in "Multiple Devices" lesson.
+						* This is a synchronous operation.
 					</div>
 				</section>
 				<!--Slide 6-->


### PR DESCRIPTION
This PR proposed changes to the "Using_USM" slides on the blocking behavior of USM `malloc` and `free`, and "Fast Track" identical slides.

Currently the slides say that `malloc_device` and `free` are blocking, however I feel that terminology could be misleading to beginners as with the `queue` parameter it implies the entry-points could be asynchronous, which they are not. I think it is more informative to say that the entry-points are synchronous which is terminology used in the other lessons

For `sycl::free` in particular I believe the following bullet points were incorrect for the following reasons:
* "This is a blocking operation.", we explicitly added a note in https://github.com/KhronosGroup/SYCL-Docs/pull/758 saying it could be blocking or non-blocking.
* "The `queue` must be the same as was used to allocate the memory.", I don't see this wording anywhere in the spec and not sure if it would be enforceable given a USM allocation can be made using a `malloc` entry-point taking a device and context rather than a queue