### PR TITLE
Fix typos in "In_Order_Queue" lesson

### DIFF
--- a/Lesson_Materials/In_Order_Queue/index.html
+++ b/Lesson_Materials/In_Order_Queue/index.html
@@ -159,7 +159,7 @@ Q.wait();
 						<div class="col" data-markdown>
 							* All commands are executed serially
 							* Ease of programming (no race conditions can occur)
-							* Potentialy lower-latency than out-of-order queues
+							* Potentially lower-latency than out-of-order queues
 							* Doesn't allow concurrency, potentially suboptimal performance
 						</div>
 					</div>
@@ -171,7 +171,10 @@ Q.wait();
 					<div class="container">
 						<div class="col">
 							<code class="code-100pc"><pre>
-std::vector<std::pair<sycl::queue, std::function>> queues_tasks;
+using queue_task_pair =
+  std::pair&ltsycl::queue, std::function&gt;;
+std::vector&ltqueue_task_pair&gt queues_tasks;
+
 for (auto [Q, task]: queues_tasks)
   Q.submit(task);
 
@@ -181,7 +184,7 @@ for (auto [Q, _]: queues_tasks)
 						</div>
 						<div class="col" data-markdown>
 							* Manual Scheduling (tasks need to be mapped to queues)
-							* Allow concurency between queues
+							* Allow concurrency between queues
 							* Painful to extract full concurrency
 						</div>
 					</div>
@@ -212,7 +215,7 @@ for (auto [Q, _]: queues_tasks)
 					</div>
 					<div class="container" data-markdown>
 						- Transform the serial in-order scheduling to allow concurrent execution (using an out-of-order queue or multiple in-order queues)
-						- Mesure speedup
+						- Measure speedup
 					</div>
 				</section>
 				<section>

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Pull Request so that they can be reviewed and merged in a timely manner.
 
 ### List of Contributors
 
-Codeplay Software Ltd., Heidelberg University, Intel, Xilinx and University of Bristol.
+Codeplay Software Ltd., Heidelberg University, Intel, Xilinx, University of Bristol,
+and Stream HPC.
 
 ## Supporting Organizations
 


### PR DESCRIPTION
Updates the slides for the "In Order Queue" lesson to fix typos.

In particular the change in the code snippet is because the `<` & `>` characters required for the template instantiating don't render. Instead you can use `&lt` & `&gt`, but when doing this the rendered line of code became too long for the slide and so I split it across two lines with a `using` alias, but open to alternative ways of splitting the line.

**Rendered code snippet on tip**
<img width="634" height="223" alt="image" src="https://github.com/user-attachments/assets/d3962b94-f64b-42bd-845a-ebc0be5f7b8c" />

**Rendered code snippet with PR**
<img width="634" height="290" alt="image" src="https://github.com/user-attachments/assets/5d7765eb-b51a-46dc-aa7c-88719fef9730" />


Additionally added Stream HPC to the list of contributors in the README, since I'm making contributions while working for them.