### PR TITLE
Fix Image Convolution exercise links

### DIFF
--- a/Code_Exercises/CMakeLists.txt
+++ b/Code_Exercises/CMakeLists.txt
@@ -42,9 +42,9 @@ function( add_sycl_executable prefix source )
     add_sycl_executable_adaptivecpp(${prefix} ${source})
   endif()
 
-  # Add ctest target for lesson solution executables only, as lesson source
-  # executables are not guaranteed to be valid SYCL.
-  if (source STREQUAL "solution")
+  # Add ctest target for lesson solution & reference executables only,
+  # as lesson source executables are not guaranteed to be valid SYCL.
+  if (source STREQUAL "solution" OR source STREQUAL "reference")
     set(TARGET_NAME "${prefix}_${source}")
     add_test(NAME "${TARGET_NAME}_test" COMMAND ${TARGET_NAME})
   endif()

--- a/README.md
+++ b/README.md
@@ -406,7 +406,7 @@ cmake ../ "-GUnix Makefiles" -DSYCL_ACADEMY_USE_DPCPP=ON -DSYCL_ACADEMY_ENABLE_S
 
 [lesson-14-slides]: ./Lesson_Materials/Image_Convolution/
 [lesson-14-exercise]: ./Code_Exercises/Image_Convolution/README.md
-[lesson-14-source]:   ./Code_Exercises/Image_Convolution/source.cpp
+[lesson-14-source]:   ./Code_Exercises/Image_Convolution
 [lesson-14-solution]: ./Code_Exercises/Image_Convolution/reference.cpp
 
 [lesson-15-slides]: ./Lesson_Materials/Coalesced_Global_Memory/


### PR DESCRIPTION
The README link to the exercise source for the "Image Convolution" lesson is invalid as no `source.cpp` file exists for this lesson's exercise. There is only a `reference.cpp` file, as the objective of this lesson is introducing the image convolution algorithm rather than a new SYCL concept.

Fixed link by pointing at the exercise directory itself, also extended the ctest check to cover `reference.cpp` targets as it currently only covers `solution.cpp` files.