### PR TITLE
Fix Lesson 4 slide code snippets

### DIFF
--- a/Lesson_Materials/Handling_Errors/index.html
+++ b/Lesson_Materials/Handling_Errors/index.html
@@ -91,7 +91,7 @@ int main() {
 
     /* Synchronous code */
 
-    cgh.parallel_for&lt;add&gt;(bufO.get_range(), [=](id&lt;1&gt; i) {
+    cgh.single_task&lt;add&gt;([=]() {
 
       /* Asynchronous code */
 
@@ -131,7 +131,7 @@ int main() {
   q.submit([&](handler &cgh) {
     /* Synchronous code */
 
-    cgh.single_task&lt;add&gt;([=](id&lt;1&gt; i) {
+    cgh.single_task&lt;add&gt;([=]() {
       /* Asynchronous code */
     });
   }).wait();


### PR DESCRIPTION
This PR is inspired by the Lesson 4 `index.html` changes in https://github.com/KhronosGroup/syclacademy/pull/326 and fixes up the `handler::single_task` invocations in a couple of places to make sure they are correct.

* Change `parallel_for` to `single_task` in early example where we haven't defined `bufO` yet to call `bufO.get_range()` on.
* Remove `(id<1> i)` parameter for `single_task` lambda invocation, as this shouldn't have any parameters.