### PR TITLE
Reword coalesced exercise README

### DIFF
--- a/Code_Exercises/Coalesced_Global_Memory/README.md
+++ b/Code_Exercises/Coalesced_Global_Memory/README.md
@@ -14,14 +14,13 @@ coalesced global memory access.
 Now that you have a working image convolution kernel you should evaluate whether the
 global memory access patterns in your kernel are coalesced.
 
-Consider two alternative ways to linearize the global id:
+SYCL buffer & accessor objects can be multi-dimensional, and in this image convolution
+example 2d buffer/accessors are used which are operated on in the kernel using a
+`sycl::id<2>` 2d index. This operation will
+[calculate](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:multi-dim-linearization)
+the linear address in memory based on the size of the dimensions.
 
-```
-auto rowMajorLinearId    = (idx[1] * width) + idx[0];  // row-major
-auto columnMajorLinearId = (idx[0] * height) + idx[1];  // column-major
-```
-
-Try using both of these and compare the execution time of each.
+Try inverting the dimensions used in the 2d index and compare the execution time.
 
 ## Build and execution hints
 


### PR DESCRIPTION
This PR tries to resolve the issue highlighted in https://github.com/KhronosGroup/syclacademy/pull/326 where the "Coalesced Global Memory" exercise README was asking a user to manually calculate a linear id that would be used to index memory.

However, the exercise code itself uses 2d buffers/accessors which are indexed with a `sycl::id<2>` rather than a `size_t`. So the current exercise request doesn't make sense, or could only be achieved with modifications beyond what is reasonably expected for a beginner.

Instead, I've updated the README to state the usage of the 2d buffer/accessors and ask the user to experiment with flipping the dimension indexes, as this is the only difference between this exercise solution, and the solution from the previous lesson

```sh
$ diff Code_Exercises/Coalesced_Global_Memory/solution.cpp Code_Exercises/Image_Convolution/reference.cpp
59a60
>
77a79
>                     globalId = sycl::id{globalId[1], globalId[0]};
```