### PR TITLE
Fix bug in LessonChecker.py

### DIFF
--- a/Lesson_Materials/Image_Convolution/index.html
+++ b/Lesson_Materials/Image_Convolution/index.html
@@ -146,8 +146,8 @@
 						#### Input/output image locations
 					</div>
 					<div class="container">
-						<code class="language-cpp" data-line-numbers>
-							<pre>
+						<pre><code class="language-cpp" data-line-numbers>
+							
 auto inputImageFile = "../Code_Exercises/Images/dogs.png";
 auto outputImageFile = ../Code_Exercises/Images/blurred_dogs.png";
 						</code></pre>
@@ -166,8 +166,8 @@ auto outputImageFile = ../Code_Exercises/Images/blurred_dogs.png";
 						#### Convolution filters
 					</div>
 					<div class="container">
-						<code class="language-cpp" data-line-numbers>
-							<pre>
+						<pre><code class="language-cpp" data-line-numbers>
+							
 auto filter = util::generate_filter(util::filter_type filterType, int width);
 						</code></pre>
 					</div>

--- a/Scripts/LessonChecker.py
+++ b/Scripts/LessonChecker.py
@@ -189,9 +189,9 @@ class SYCLAParser(HTMLParser):
                 self._warn(
                     f"misalligned <code> and <pre> tags in lesson {self.lesson_name} line num: {self.getpos()[0]}"
                 )
-
-                if "code" in self.output[-1]:
-                    self.output.insert(-1, "<pre>")
+                lcode = self.last_code_idx 
+                if "code" in self.output[lcode]: #pyright: ignore
+                    self.output.insert(lcode, "<pre>") #pyright: ignore
                     return
 
             case _:
@@ -209,7 +209,7 @@ class SYCLAParser(HTMLParser):
                         f"&lt;{raw_tag.lstrip("<").rstrip(">")}&gt;"  # pyright: ignore
                     )
                     return
-
+        
         self.output.append(self._encode_attrs(tag, attrs))
 
     def handle_data(self, data):

--- a/Scripts/LessonChecker.py
+++ b/Scripts/LessonChecker.py
@@ -190,8 +190,11 @@ class SYCLAParser(HTMLParser):
                     f"misalligned <code> and <pre> tags in lesson {self.lesson_name} line num: {self.getpos()[0]}"
                 )
                 lcode = self.last_code_idx 
-                if "code" in self.output[lcode]: #pyright: ignore
-                    self.output.insert(lcode, "<pre>") #pyright: ignore
+
+                assert lcode is not None
+
+                if "code" in self.output[lcode]:
+                    self.output.insert(lcode, "<pre>") 
                     return
 
             case _:
@@ -205,11 +208,13 @@ class SYCLAParser(HTMLParser):
                     # Fetch the original case of the impropperly escaped code
                     raw_tag = self.get_starttag_text()
 
+                    assert raw_tag is not None
+
                     self.output.append(
-                        f"&lt;{raw_tag.lstrip("<").rstrip(">")}&gt;"  # pyright: ignore
+                        f"&lt;{raw_tag.lstrip("<").rstrip(">")}&gt;"  
                     )
                     return
-        
+
         self.output.append(self._encode_attrs(tag, attrs))
 
     def handle_data(self, data):

--- a/Scripts/test_LessonChecker.py
+++ b/Scripts/test_LessonChecker.py
@@ -134,6 +134,16 @@ test_cases = [
         "expected_output": '<pre><code class="language-cpp" data-line-numbers></code></pre>',
     },
     {
+        "name": "fix_mismatched_pre_code_newline_tabs_between_code_pre",
+        "body": "<code>\n\t\t\t\t\t\t<pre></code></pre>",
+        "extract": False,
+        "verify": False,
+        "fix": True,
+        "silent": True,
+        "expected_return": True,
+        "expected_output": '<pre><code class="language-cpp" data-line-numbers>\n\t\t\t\t\t\t</code></pre>',
+    },
+    {
         "name": "fix_improper_escaped_ref",
         "body": '<pre><code class="language-cpp" data-line-numbers>&evt</code></pre>',
         "extract": False,


### PR DESCRIPTION
This PR seeks to fix a bug in the LessonChecker.py script where when a `<pre>` and `<code>` tag are swapped and there is any kind of white space character other than `\n` between them like `\t` the parser fails to swap the tags due to how it always checked the last member of `self.output`, for a `<code>` tag, when in this case its actually one or more `\t` characters. 

I fixed the bug by having the parser use the `last_code_idx` property. I introduced an appropriate test to prevent regression. 

This issue was discovered when image_convolution failed evaluation with LessonChecker.py. It correctly identified the issue, but auto fix failed to fix the issue since the last element of `self.output` was `\n\t\t\t\t...` instead of the expected `<code>`. This PR also includes the autofixed image_convolution lesson.